### PR TITLE
Fixes methods without EventSubscriber annotations being added as method listeners

### DIFF
--- a/src/main/java/sx/blah/discord/handle/EventDispatcher.java
+++ b/src/main/java/sx/blah/discord/handle/EventDispatcher.java
@@ -32,12 +32,14 @@ public class EventDispatcher {
 	public void registerListener(Object listener) {
 		for (Method method : listener.getClass().getDeclaredMethods()) {
 			if (method.getParameterCount() == 1) {
-				Class<?> eventClass = method.getParameterTypes()[0];
-				if (Event.class.isAssignableFrom(eventClass)) {
-					if (!methodListeners.containsKey(eventClass))
-						methodListeners.put(eventClass, new HashMap<>());
-					
-					methodListeners.get(eventClass).put(method, listener);
+				if (method.isAnnotationPresent(EventSubscriber.class)) {
+					Class<?> eventClass = method.getParameterTypes()[0];
+					if (Event.class.isAssignableFrom(eventClass)) {
+						if (!methodListeners.containsKey(eventClass))
+							methodListeners.put(eventClass, new HashMap<>());
+
+						methodListeners.get(eventClass).put(method, listener);
+					}
 				}
 			}
 		}


### PR DESCRIPTION
I discovered an issue where method signatures without the EventSubscriber annotation were being added as method listeners if they contained a single parameter which was of an Event type. I traced this issue back to the EventDispatcher class, where it was not validating that the annotation existed before adding the method to the methodListeners map. I've added this check in this pull request.

Here is a test class which reproduces the issue:

    public class TestListener {

        @EventSubscriber
        public void onMessageReceivedEvent(MessageReceivedEvent event) throws Exception {
            // this method is invoked as expected
            event.getMessage().reply("Hello there!");
        }

        public void whoops(MessageReceivedEvent event) throws Exception {
            // this method is also invoked, even though it lacks the correct annotation
            event.getMessage().reply("You shouldn't be seeing this!");
        }
    }