### PR TITLE
MessageList improvements and fixes

### DIFF
--- a/src/main/java/sx/blah/discord/util/MessageList.java
+++ b/src/main/java/sx/blah/discord/util/MessageList.java
@@ -78,7 +78,11 @@ public class MessageList extends AbstractList<IMessage> implements List<IMessage
 	public MessageList(IDiscordClient client, IChannel channel, int initialContents) {
 		this(client, channel);
 
-		load(initialContents);
+		try {
+			load(initialContents);
+		} catch (HTTP429Exception e) {
+			Discord4J.LOGGER.error("Discord4J Internal Exception", e);
+		}
 	}
 
 	/**
@@ -261,11 +265,12 @@ public class MessageList extends AbstractList<IMessage> implements List<IMessage
 	 *
 	 * @param messageCount The amount of messages to load.
 	 * @return True if this action was successful, false if otherwise.
+	 * @throws HTTP429Exception
 	 */
-	public boolean load(int messageCount) {
+	public boolean load(int messageCount) throws HTTP429Exception {
 		try {
 			return queryMessages(messageCount);
-		} catch (DiscordException | HTTP429Exception e) {
+		} catch (DiscordException e) {
 			Discord4J.LOGGER.error("Discord4J Internal Exception", e);
 		}
 		return false;

--- a/src/main/java/sx/blah/discord/util/MessageList.java
+++ b/src/main/java/sx/blah/discord/util/MessageList.java
@@ -31,7 +31,7 @@ public class MessageList extends AbstractList<IMessage> implements List<IMessage
 	/**
 	 * This represents the amount of messages to fetch from discord every time the index goes out of bounds.
 	 */
-	public static final int MESSAGE_CHUNK_COUNT = 50;
+	public static final int MESSAGE_CHUNK_COUNT = 100;
 
 	/**
 	 * The client that this list is respecting.

--- a/src/main/java/sx/blah/discord/util/MessageList.java
+++ b/src/main/java/sx/blah/discord/util/MessageList.java
@@ -125,6 +125,10 @@ public class MessageList extends AbstractList<IMessage> implements List<IMessage
 
 		MessageResponse[] messages = DiscordUtils.GSON.fromJson(response, MessageResponse[].class);
 
+		if (messages.length == 0) {
+			return false;
+		}
+
 		for (MessageResponse messageResponse : messages)
 			if (!add(DiscordUtils.getMessageFromJSON(client, channel, messageResponse)))
 				return false;


### PR DESCRIPTION
#### Issues Fixed

- Fixes an issue where reaching the beginning of message history would return `true` even if it didn't load any message

#### Changes Proposed in this Pull Request

- Allows a user to handle potential 429 errors occurred when querying channel messages
- Increases the number of messages queried from 50 to the current API maximum (100)
