### PR TITLE
Added user to UserVoiceChannel(Join/Leave/Move)Event

### DIFF
--- a/src/main/java/sx/blah/discord/api/internal/DiscordWS.java
+++ b/src/main/java/sx/blah/discord/api/internal/DiscordWS.java
@@ -813,11 +813,11 @@ public class DiscordWS {
 			((User) user).setVoiceChannel(channel);
 			if (channel != oldChannel) {
 				if (channel == null) {
-					client.dispatcher.dispatch(new UserVoiceChannelLeaveEvent(oldChannel));
+					client.dispatcher.dispatch(new UserVoiceChannelLeaveEvent(user, oldChannel));
 				} else if (oldChannel == null) {
-					client.dispatcher.dispatch(new UserVoiceChannelJoinEvent(channel));
+					client.dispatcher.dispatch(new UserVoiceChannelJoinEvent(user, channel));
 				} else {
-					client.dispatcher.dispatch(new UserVoiceChannelMoveEvent(oldChannel, channel));
+					client.dispatcher.dispatch(new UserVoiceChannelMoveEvent(user, oldChannel, channel));
 				}
 			} else {
 				client.dispatcher.dispatch(new UserVoiceStateUpdateEvent(user, channel, event.self_mute, event.self_deaf, event.mute, event.deaf, event.suppress));

--- a/src/main/java/sx/blah/discord/handle/impl/events/UserVoiceChannelJoinEvent.java
+++ b/src/main/java/sx/blah/discord/handle/impl/events/UserVoiceChannelJoinEvent.java
@@ -1,22 +1,38 @@
 package sx.blah.discord.handle.impl.events;
 
 import sx.blah.discord.api.Event;
+import sx.blah.discord.handle.obj.IUser;
 import sx.blah.discord.handle.obj.IVoiceChannel;
 
 /**
  * This event is dispatched when a user connects to a voice channel.
  */
 public class UserVoiceChannelJoinEvent extends Event {
-
+	
+	/**
+	 * The channel that has joined.
+	 */
+	private final IUser user;
+	
 	/**
 	 * The channel the user joined.
 	 */
 	private final IVoiceChannel newChannel;
 
-	public UserVoiceChannelJoinEvent(IVoiceChannel newChannel) {
+	public UserVoiceChannelJoinEvent(IUser user, IVoiceChannel newChannel) {
+		this.user = user;
 		this.newChannel = newChannel;
 	}
-
+	
+	/**
+	 * Retrieves the user that has joined the channel.
+	 *
+	 * @return The user that has joined the channel.
+	 */
+	public IUser getUser() {
+		return user;
+	}
+	
 	/**
 	 * Gets the voice channel this user joined.
 	 *

--- a/src/main/java/sx/blah/discord/handle/impl/events/UserVoiceChannelJoinEvent.java
+++ b/src/main/java/sx/blah/discord/handle/impl/events/UserVoiceChannelJoinEvent.java
@@ -10,7 +10,7 @@ import sx.blah.discord.handle.obj.IVoiceChannel;
 public class UserVoiceChannelJoinEvent extends Event {
 	
 	/**
-	 * The channel that has joined.
+	 * The user that has joined.
 	 */
 	private final IUser user;
 	

--- a/src/main/java/sx/blah/discord/handle/impl/events/UserVoiceChannelLeaveEvent.java
+++ b/src/main/java/sx/blah/discord/handle/impl/events/UserVoiceChannelLeaveEvent.java
@@ -10,7 +10,7 @@ import sx.blah.discord.handle.obj.IVoiceChannel;
 public class UserVoiceChannelLeaveEvent extends Event {
 
 	/**
-	 * The channel that has left.
+	 * The user that has left.
 	 */
 	private final IUser user;
 	

--- a/src/main/java/sx/blah/discord/handle/impl/events/UserVoiceChannelLeaveEvent.java
+++ b/src/main/java/sx/blah/discord/handle/impl/events/UserVoiceChannelLeaveEvent.java
@@ -1,6 +1,7 @@
 package sx.blah.discord.handle.impl.events;
 
 import sx.blah.discord.api.Event;
+import sx.blah.discord.handle.obj.IUser;
 import sx.blah.discord.handle.obj.IVoiceChannel;
 
 /**
@@ -9,14 +10,29 @@ import sx.blah.discord.handle.obj.IVoiceChannel;
 public class UserVoiceChannelLeaveEvent extends Event {
 
 	/**
+	 * The channel that has left.
+	 */
+	private final IUser user;
+	
+	/**
 	 * The channel the user left.
 	 */
 	private final IVoiceChannel oldChannel;
 
-	public UserVoiceChannelLeaveEvent(IVoiceChannel oldChannel) {
+	public UserVoiceChannelLeaveEvent(IUser user, IVoiceChannel oldChannel) {
+		this.user = user;
 		this.oldChannel = oldChannel;
 	}
 
+	/**
+	 * Retrieves the user that has left the channel.
+	 *
+	 * @return The user that has left the channel.
+	 */
+	public IUser getUser() {
+		return user;
+	}
+	
 	/**
 	 * Gets the voice channel this user left.
 	 *

--- a/src/main/java/sx/blah/discord/handle/impl/events/UserVoiceChannelMoveEvent.java
+++ b/src/main/java/sx/blah/discord/handle/impl/events/UserVoiceChannelMoveEvent.java
@@ -1,6 +1,7 @@
 package sx.blah.discord.handle.impl.events;
 
 import sx.blah.discord.api.Event;
+import sx.blah.discord.handle.obj.IUser;
 import sx.blah.discord.handle.obj.IVoiceChannel;
 
 /**
@@ -9,19 +10,35 @@ import sx.blah.discord.handle.obj.IVoiceChannel;
 public class UserVoiceChannelMoveEvent extends Event {
 
 	/**
+	 * The channel that has moved.
+	 */
+	private final IUser user;
+	
+	/**
 	 * The channel the user left.
 	 */
 	private final IVoiceChannel oldChannel;
+	
 	/**
 	 * The channel the user joined.
 	 */
 	private final IVoiceChannel newChannel;
 
-	public UserVoiceChannelMoveEvent(IVoiceChannel oldChannel, IVoiceChannel newChannel) {
+	public UserVoiceChannelMoveEvent(IUser user, IVoiceChannel oldChannel, IVoiceChannel newChannel) {
+		this.user = user;
 		this.oldChannel = oldChannel;
 		this.newChannel = newChannel;
 	}
-
+	
+	/**
+	 * Retrieves the user that has moved to another channel.
+	 *
+	 * @return The user that has moved.
+	 */
+	public IUser getUser() {
+		return user;
+	}
+	
 	/**
 	 * Gets the voice channel this user left.
 	 *

--- a/src/main/java/sx/blah/discord/handle/impl/events/UserVoiceChannelMoveEvent.java
+++ b/src/main/java/sx/blah/discord/handle/impl/events/UserVoiceChannelMoveEvent.java
@@ -10,7 +10,7 @@ import sx.blah.discord.handle.obj.IVoiceChannel;
 public class UserVoiceChannelMoveEvent extends Event {
 
 	/**
-	 * The channel that has moved.
+	 * The user that has moved.
 	 */
 	private final IUser user;
 	


### PR DESCRIPTION
### Prerequisites
* [x] I have read and understand the [contribution guidelines](CONTRIBUTING.md)
* [x] This pull request follows the code style of the project
* [ ] I have tested this feature thoroughly

I haven't tested it yet, but it's a small change and I can't see why it shouldn't work.

**Issues Fixed:** none

### Changes Proposed in this Pull Request
* Added a IUser field and getter to `UserVoiceChannel(Join/Leave/Move)Event`

Before, you couldn't check which user joined, left or moved to another channel.