### PR TITLE
Fixes ModuleLoader not being able to read 'module-requires'

### DIFF
--- a/src/main/java/sx/blah/discord/modules/ModuleLoader.java
+++ b/src/main/java/sx/blah/discord/modules/ModuleLoader.java
@@ -16,6 +16,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.jar.Attributes;
 import java.util.jar.JarFile;
 import java.util.jar.Manifest;
 import java.util.stream.Collectors;
@@ -223,7 +224,7 @@ public class ModuleLoader {
 				JarFile jarFile = new JarFile(file);
 				Manifest manifest = jarFile.getManifest();
 				if (manifest != null && manifest.getMainAttributes() != null
-						&& manifest.getMainAttributes().containsKey("module-requires")) {
+						&& manifest.getMainAttributes().containsKey(new Attributes.Name("module-requires"))) {
 					dependents.add(file);
 				} else {
 					independents.add(file);


### PR DESCRIPTION
### Prerequisites
* [x] I have read and understand the [contribution guidelines](CONTRIBUTING.md)
* [x] This pull request follows the code style of the project
* [x] I have tested this feature thoroughly

**Issues Fixed:** Fixes a minor bug in ModuleLoader that was reading all MANIFEST 'module-requires' keys as false.
