### PR TITLE
Made IVoiceChannel#join check for valid permissions.

### DIFF
--- a/src/main/java/sx/blah/discord/handle/impl/obj/VoiceChannel.java
+++ b/src/main/java/sx/blah/discord/handle/impl/obj/VoiceChannel.java
@@ -5,19 +5,13 @@ import sx.blah.discord.api.IDiscordClient;
 import sx.blah.discord.api.internal.DiscordClientImpl;
 import sx.blah.discord.api.internal.DiscordUtils;
 import sx.blah.discord.handle.impl.events.VoiceDisconnectedEvent;
-import sx.blah.discord.handle.obj.IGuild;
-import sx.blah.discord.handle.obj.IMessage;
-import sx.blah.discord.handle.obj.IUser;
-import sx.blah.discord.handle.obj.IVoiceChannel;
+import sx.blah.discord.handle.obj.*;
 import sx.blah.discord.json.requests.VoiceChannelRequest;
 import sx.blah.discord.util.*;
 
 import java.io.File;
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.stream.Collectors;
 
 public class VoiceChannel extends Channel implements IVoiceChannel {
@@ -48,9 +42,9 @@ public class VoiceChannel extends Channel implements IVoiceChannel {
 	}
 
 	@Override
-	public void join() {
+	public void join() throws MissingPermissionsException {
 		if (client.isReady()) {
-
+			DiscordUtils.checkPermissions(client, this, EnumSet.of(Permissions.VOICE_CONNECT));
 			if (!client.getOurUser().getConnectedVoiceChannels().contains(this)) {
 				if (((DiscordClientImpl) client).voiceConnections.containsKey(parent)) {
 					Discord4J.LOGGER.info(LogMarkers.HANDLE, "Attempting to join multiple channels in the same guild! Moving channels instead...");

--- a/src/main/java/sx/blah/discord/handle/obj/IVoiceChannel.java
+++ b/src/main/java/sx/blah/discord/handle/obj/IVoiceChannel.java
@@ -1,5 +1,7 @@
 package sx.blah.discord.handle.obj;
 
+import sx.blah.discord.util.MissingPermissionsException;
+
 import java.util.List;
 
 /**
@@ -15,8 +17,10 @@ public interface IVoiceChannel extends IChannel {
 
 	/**
 	 * Makes the bot user join this voice channel.
+	 *
+	 * @throws MissingPermissionsException
 	 */
-	void join();
+	void join() throws MissingPermissionsException;
 
 	/**
 	 * Makes the bot user leave this voice channel.

--- a/src/test/java/sx/blah/discord/VoiceBot.java
+++ b/src/test/java/sx/blah/discord/VoiceBot.java
@@ -8,6 +8,7 @@ import sx.blah.discord.handle.impl.events.ReadyEvent;
 import sx.blah.discord.handle.impl.events.VoiceUserSpeakingEvent;
 import sx.blah.discord.handle.obj.IGuild;
 import sx.blah.discord.handle.obj.IVoiceChannel;
+import sx.blah.discord.util.MissingPermissionsException;
 
 public class VoiceBot {
     public static void main(String... args) {
@@ -16,14 +17,16 @@ public class VoiceBot {
             client.getConnectedVoiceChannels().get(0).getGuild().getAudioChannel().queueFile(args[3]);
 
             client.getDispatcher().registerListener(new IListener<ReadyEvent>() {
-
-
 				@Override
                 public void handle(ReadyEvent event) {
-                    IGuild guild = client.getGuilds().get(1);
-                    IVoiceChannel voiceChannel = guild.getVoiceChannels().get(0);
-                    voiceChannel.join();
-                }
+					try {
+						IGuild guild = client.getGuilds().get(1);
+						IVoiceChannel voiceChannel = guild.getVoiceChannels().get(0);
+						voiceChannel.join();
+					} catch (MissingPermissionsException e) {
+						e.printStackTrace();
+					}
+				}
             });
 
             client.getDispatcher().registerListener(new IListener<VoiceUserSpeakingEvent>() {


### PR DESCRIPTION
### Prerequisites
* [x] I have read and understand the [contribution guidelines](CONTRIBUTING.md)
* [x] This pull request follows the code style of the project
* [x] I have tested this feature thoroughly

**Issues Fixed:** Someone( can't remember your name D: ) brought up how `IVoiceChannel#join` doesn't properly check if you don't have permissions to join the voice channel, so now it does before doing anything.

### Changes Proposed in this Pull Request
* join() now checks for the VOICE_CONNECT permission before trying to do anything.
* As a result it throws MIssingPermissionException now
* Updated VoiceBot to reflect that change



