### PR TITLE
More efficient Guild#getUserById()

### DIFF
--- a/src/main/java/sx/blah/discord/handle/impl/obj/Guild.java
+++ b/src/main/java/sx/blah/discord/handle/impl/obj/Guild.java
@@ -177,8 +177,7 @@ public class Guild implements IGuild {
 	public IUser getUserByID(String id) {
 		if (users == null)
 			return null;
-		List<IUser> usersCopy = new ArrayList<>(users);
-		return usersCopy.stream()
+		return Arrays.stream(users.toArray(new IUser[users.size()]))
 				.filter(u -> u != null && u.getID() != null && u.getID().equalsIgnoreCase(id))
 				.findAny().orElse(null);
 	}


### PR DESCRIPTION
### Prerequisites
* [x] I have read and understand the [contribution guidelines](CONTRIBUTING.md)
* [x] This pull request follows the code style of the project
* [x] I have tested this feature thoroughly

**Issues Fixed:** [The issues fixed by this pull request]
N/A

### Changes Proposed in this Pull Request
Instead of creating a new ArrayList and streaming that, we just stream a copy of the original ArrayList's backing array. Shouldn't actually impact functionality, as the previously used ArrayList constructor already calls Collection#toArray() anyways.