### PR TITLE
Throw UnsupportedOperationException when trying to mention a voice ch…

### DIFF
--- a/src/main/java/sx/blah/discord/handle/impl/obj/VoiceChannel.java
+++ b/src/main/java/sx/blah/discord/handle/impl/obj/VoiceChannel.java
@@ -159,6 +159,11 @@ public class VoiceChannel extends Channel implements IVoiceChannel {
 	public String getTopic() {
 		throw new UnsupportedOperationException();
 	}
+	
+	@Override
+	public String mention(){
+		throw new UnsupportedOperationException();
+	}
 
 	@Override
 	public void setTopic(String topic) {
@@ -213,5 +218,10 @@ public class VoiceChannel extends Channel implements IVoiceChannel {
 	@Override
 	public List<IUser> getConnectedUsers() {
 		return parent.getUsers().stream().filter((user) -> user.getConnectedVoiceChannels().contains(this)).collect(Collectors.toList());
+	}
+	
+	@Override
+	public String toString(){
+		return getName();
 	}
 }


### PR DESCRIPTION
### Prerequisites
* [x] I have read and understand the [contribution guidelines](CONTRIBUTING.md)
* [x] This pull request follows the code style of the project
* [x] I have tested this feature thoroughly

**Issues Fixed:** Issue #63 

### Changes Proposed in this Pull Request
* VoiceChannel.mention() throws UnsupportedOperationException
* VoiceChannel.toString() returns getName()
