### PR TITLE
Differentiate CloudFlare 502 vs Discord 502 ("probably caused by cloudflare") 

### DIFF
--- a/src/main/java/sx/blah/discord/api/internal/DiscordWS.java
+++ b/src/main/java/sx/blah/discord/api/internal/DiscordWS.java
@@ -728,9 +728,9 @@ public class DiscordWS {
 
 			toUpdate = (Message) DiscordUtils.getMessageFromJSON(client, channel, event);
 
-			if (toUpdate.isPinned() && !event.pinned) {
+			if (oldMessage.isPinned() && !event.pinned) {
 				client.dispatcher.dispatch(new MessageUnpinEvent(toUpdate));
-			} else if (!toUpdate.isPinned() && event.pinned) {
+			} else if (!oldMessage.isPinned() && event.pinned) {
 				client.dispatcher.dispatch(new MessagePinEvent(toUpdate));
 			} else {
 				client.dispatcher.dispatch(new MessageUpdateEvent(oldMessage, toUpdate));

--- a/src/main/java/sx/blah/discord/api/internal/Requests.java
+++ b/src/main/java/sx/blah/discord/api/internal/Requests.java
@@ -148,7 +148,7 @@ public enum Requests {
 							+ ". This is due to CloudFlare (detected \"cloudflare-nginx\" in message).");
 				}
 				
-				throw new DiscordException("502 error on request to "+request.getURI()+". This is probably due to cloudflare, in which case you can ignore this.");
+				throw new DiscordException("502 error on request to "+request.getURI()+".");
 			} else if ((responseCode < 200 || responseCode > 299) && responseCode != 429) {
 				throw new DiscordException("Error on request to "+request.getURI()+". Received response code "+responseCode+". With response text: "+message);
 			}

--- a/src/main/java/sx/blah/discord/api/internal/Requests.java
+++ b/src/main/java/sx/blah/discord/api/internal/Requests.java
@@ -17,6 +17,7 @@ import sx.blah.discord.util.LogMarkers;
 
 import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
+import java.util.Locale;
 
 import static sx.blah.discord.Discord4J.*;
 
@@ -141,6 +142,12 @@ public enum Requests {
 				return null;
 			} else if (responseCode == 502) {
 				LOGGER.trace(LogMarkers.API, "502 response on request to {}, response text: {}", request.getURI(), message); //This can be used to verify if it was cloudflare causing the 502.
+				
+				if (message.toLowerCase(Locale.ROOT).contains("cloudflare-nginx")) {
+					throw new DiscordException("502 error on request to " + request.getURI()
+							+ ". This is due to CloudFlare (detected \"cloudflare-nginx\" in message).");
+				}
+				
 				throw new DiscordException("502 error on request to "+request.getURI()+". This is probably due to cloudflare, in which case you can ignore this.");
 			} else if ((responseCode < 200 || responseCode > 299) && responseCode != 429) {
 				throw new DiscordException("Error on request to "+request.getURI()+". Received response code "+responseCode+". With response text: "+message);

--- a/src/main/java/sx/blah/discord/api/internal/Requests.java
+++ b/src/main/java/sx/blah/discord/api/internal/Requests.java
@@ -143,7 +143,7 @@ public enum Requests {
 			} else if (responseCode == 502) {
 				LOGGER.trace(LogMarkers.API, "502 response on request to {}, response text: {}", request.getURI(), message); //This can be used to verify if it was cloudflare causing the 502.
 				
-				if (message.toLowerCase(Locale.ROOT).contains("cloudflare-nginx")) {
+				if (message.contains("cloudflare-nginx")) {
 					throw new DiscordException("502 error on request to " + request.getURI()
 							+ ". This is due to CloudFlare (detected \"cloudflare-nginx\" in message).");
 				}


### PR DESCRIPTION
### Prerequisites
* [x] I have read and understand the [contribution guidelines](CONTRIBUTING.md)
* [x] This pull request follows the code style of the project
* [x] I have tested this feature thoroughly

### Changes Proposed in this Pull Request
* Added a separate error message for DiscordException when the text "cloudflare-nginx" is detected in the message.
  * This also removes the "probably caused by cloudflare" message in the original 502 exception. This was added because some developers (like myself) detect for a CloudFlare 502 and use that to attempt to retry sending the message at a later point.

