### PR TITLE
Fixes override caching, connectedVoiceChannels caching and permission checks

### DIFF
--- a/src/main/java/sx/blah/discord/api/internal/DiscordUtils.java
+++ b/src/main/java/sx/blah/discord/api/internal/DiscordUtils.java
@@ -384,21 +384,13 @@ public class DiscordUtils {
 			HashMap<String, IChannel.PermissionOverride> roleOverrides = new HashMap<>();
 			for (PermissionOverwrite overrides : json.permission_overwrites) {
 				if (overrides.type.equalsIgnoreCase("role")) {
-					if (channel.getRoleOverrides().containsKey(overrides.id)) {
-						roleOverrides.put(overrides.id, channel.getRoleOverrides().get(overrides.id));
-					} else {
-						roleOverrides.put(overrides.id, new IChannel.PermissionOverride(
-								Permissions.getAllowedPermissionsForNumber(overrides.allow),
-								Permissions.getDeniedPermissionsForNumber(overrides.deny)));
-					}
+					roleOverrides.put(overrides.id, new IChannel.PermissionOverride(
+							Permissions.getAllowedPermissionsForNumber(overrides.allow),
+							Permissions.getDeniedPermissionsForNumber(overrides.deny)));
 				} else if (overrides.type.equalsIgnoreCase("member")) {
-					if (channel.getUserOverrides().containsKey(overrides.id)) {
-						userOverrides.put(overrides.id, channel.getUserOverrides().get(overrides.id));
-					} else {
-						userOverrides.put(overrides.id, new IChannel.PermissionOverride(
-								Permissions.getAllowedPermissionsForNumber(overrides.allow),
-								Permissions.getDeniedPermissionsForNumber(overrides.deny)));
-					}
+					userOverrides.put(overrides.id, new IChannel.PermissionOverride(
+							Permissions.getAllowedPermissionsForNumber(overrides.allow),
+							Permissions.getDeniedPermissionsForNumber(overrides.deny)));
 				} else {
 					Discord4J.LOGGER.warn(LogMarkers.API, "Unknown permissions overwrite type \"{}\"!", overrides.type);
 				}
@@ -481,21 +473,13 @@ public class DiscordUtils {
 			HashMap<String, IChannel.PermissionOverride> roleOverrides = new HashMap<>();
 			for (PermissionOverwrite overrides : json.permission_overwrites) {
 				if (overrides.type.equalsIgnoreCase("role")) {
-					if (channel.getRoleOverrides().containsKey(overrides.id)) {
-						roleOverrides.put(overrides.id, channel.getRoleOverrides().get(overrides.id));
-					} else {
-						roleOverrides.put(overrides.id, new IChannel.PermissionOverride(
-								Permissions.getAllowedPermissionsForNumber(overrides.allow),
-								Permissions.getDeniedPermissionsForNumber(overrides.deny)));
-					}
+					roleOverrides.put(overrides.id, new IChannel.PermissionOverride(
+							Permissions.getAllowedPermissionsForNumber(overrides.allow),
+							Permissions.getDeniedPermissionsForNumber(overrides.deny)));
 				} else if (overrides.type.equalsIgnoreCase("member")) {
-					if (channel.getUserOverrides().containsKey(overrides.id)) {
-						userOverrides.put(overrides.id, channel.getUserOverrides().get(overrides.id));
-					} else {
-						userOverrides.put(overrides.id, new IChannel.PermissionOverride(
-								Permissions.getAllowedPermissionsForNumber(overrides.allow),
-								Permissions.getDeniedPermissionsForNumber(overrides.deny)));
-					}
+					userOverrides.put(overrides.id, new IChannel.PermissionOverride(
+							Permissions.getAllowedPermissionsForNumber(overrides.allow),
+							Permissions.getDeniedPermissionsForNumber(overrides.deny)));
 				} else {
 					Discord4J.LOGGER.warn(LogMarkers.API, "Unknown permissions overwrite type \"{}\"!", overrides.type);
 				}

--- a/src/main/java/sx/blah/discord/handle/impl/obj/Channel.java
+++ b/src/main/java/sx/blah/discord/handle/impl/obj/Channel.java
@@ -377,11 +377,21 @@ public class Channel implements IChannel {
 				.forEach(permissions::add);
 
 		PermissionOverride override = getUserOverrides().get(user.getID());
-		if (override == null)
-			return permissions;
+		List<PermissionOverride> overrideRoles = roles.stream()
+				.sorted(Collections.reverseOrder())
+				.filter(r -> roleOverrides.containsKey(r.getID()))
+				.map(role -> roleOverrides.get(role.getID()))
+				.collect(Collectors.toList());
 
-		permissions.addAll(override.allow().stream().collect(Collectors.toList()));
-		override.deny().forEach(permissions::remove);
+		for (PermissionOverride roleOverride : overrideRoles) {
+			permissions.addAll(roleOverride.allow());
+			permissions.removeAll(roleOverride.deny());
+		}
+
+		if (override != null) {
+			permissions.addAll(override.allow());
+			permissions.removeAll(override.deny());
+		}
 
 		return permissions;
 	}

--- a/src/main/java/sx/blah/discord/handle/impl/obj/Channel.java
+++ b/src/main/java/sx/blah/discord/handle/impl/obj/Channel.java
@@ -378,11 +378,10 @@ public class Channel implements IChannel {
 
 		PermissionOverride override = getUserOverrides().get(user.getID());
 		List<PermissionOverride> overrideRoles = roles.stream()
-				.sorted(Collections.reverseOrder())
 				.filter(r -> roleOverrides.containsKey(r.getID()))
 				.map(role -> roleOverrides.get(role.getID()))
 				.collect(Collectors.toList());
-
+		Collections.reverse(overrideRoles);
 		for (PermissionOverride roleOverride : overrideRoles) {
 			permissions.addAll(roleOverride.allow());
 			permissions.removeAll(roleOverride.deny());

--- a/src/main/java/sx/blah/discord/handle/impl/obj/VoiceChannel.java
+++ b/src/main/java/sx/blah/discord/handle/impl/obj/VoiceChannel.java
@@ -114,13 +114,10 @@ public class VoiceChannel extends Channel implements IVoiceChannel {
 						Discord4J.LOGGER.error(LogMarkers.HANDLE, "Unable to switch voice channels! Aborting join request...", e);
 						return;
 					}
-					((User)client.getOurUser()).channels.add(this);
 				} else if (!client.isBot() && client.getConnectedVoiceChannels().size() > 0)
 					throw new UnsupportedOperationException("Must be a bot account to have multi-server voice support!");
 
 				((DiscordClientImpl) client).ws.send(DiscordUtils.GSON.toJson(new VoiceChannelRequest(parent.getID(), id, false, false)));
-				if (!client.getOurUser().getConnectedVoiceChannels().contains(this))
-					client.getOurUser().getConnectedVoiceChannels().add(this);
 			} else {
 				Discord4J.LOGGER.info(LogMarkers.HANDLE, "Already connected to the voice channel!");
 			}
@@ -159,7 +156,7 @@ public class VoiceChannel extends Channel implements IVoiceChannel {
 	public String getTopic() {
 		throw new UnsupportedOperationException();
 	}
-	
+
 	@Override
 	public String mention(){
 		throw new UnsupportedOperationException();
@@ -219,7 +216,7 @@ public class VoiceChannel extends Channel implements IVoiceChannel {
 	public List<IUser> getConnectedUsers() {
 		return parent.getUsers().stream().filter((user) -> user.getConnectedVoiceChannels().contains(this)).collect(Collectors.toList());
 	}
-	
+
 	@Override
 	public String toString(){
 		return getName();


### PR DESCRIPTION
### Prerequisites
* [x] I have read and understand the [contribution guidelines](CONTRIBUTING.md)
* [x] This pull request follows the code style of the project
* [x] I have tested this feature thoroughly

**Issues Fixed:** #39 (Change 2 >.>)

### Changes Proposed in this Pull Request
* `IChannel.getModifedPermissions(IUser)` is slightly reworked to add and/or remove permissions based on any role override that a user is a part of.
* `IVoiceChannel#join` no longer adds channels to the cache because `DiscordWS#voiceStateUpdate` already does that and makes sure the user has actually joined the channel before doing so.
* Permission overrides are properly cached now. Previously if a role/user was already in the override cache, the new overrides from `ChannelResponse` would be ignored and the cache would remain unchanged.

The reason for the 1st change is because say the Everyone role had normal permissions but a user has another role which excludes `SEND_MESSAGE` in a certain channel, running `DiscordUtils.checkPermissions(client, thatChannel, EnumSet.of(Permissions.SEND_MESSAGE))` wouldn't throw `MissingPermissionsException`, even though the user cannot send messages in that channel.
I reversed the override list before doing the adding and removing to get the proper role hierarchy.