### PR TITLE
Added permission check to moveToVoiceChannel

### DIFF
--- a/src/main/java/sx/blah/discord/handle/impl/obj/User.java
+++ b/src/main/java/sx/blah/discord/handle/impl/obj/User.java
@@ -284,6 +284,8 @@ public class User implements IUser {
 
 	@Override
 	public void moveToVoiceChannel(IVoiceChannel newChannel) throws DiscordException, RateLimitException, MissingPermissionsException {
+		DiscordUtils.checkPermissions(client, newChannel, EnumSet.of(Permissions.VOICE_CONNECT));
+		
 		if (!client.getOurUser().equals(this))
 			DiscordUtils.checkPermissions(client, newChannel.getGuild(), this.getRolesForGuild(newChannel.getGuild()), EnumSet.of(Permissions.VOICE_MOVE_MEMBERS));
 


### PR DESCRIPTION
### Prerequisites
* [x] I have read and understand the [contribution guidelines](CONTRIBUTING.md)
* [x] This pull request follows the code style of the project
* [x] I have tested this feature thoroughly

**Issues Fixed:** Bot trying to move user to a channel when it doesn't have the perms for it instead of throwing MissingPermissionsException

### Changes Proposed in this Pull Request
* A new permission check in moveToVoiceChannel to see if the bot can join the voice channel before moving itself or others.