### PR TITLE
Fixes channel editing

### DIFF
--- a/src/main/java/sx/blah/discord/handle/impl/obj/VoiceChannel.java
+++ b/src/main/java/sx/blah/discord/handle/impl/obj/VoiceChannel.java
@@ -62,6 +62,16 @@ public class VoiceChannel extends Channel implements IVoiceChannel {
 	public void setBitrate(int bitrate) { this.bitrate = bitrate; }
 
 	@Override
+	public void changeName(String name) throws MissingPermissionsException, DiscordException, RateLimitException {
+		edit(Optional.of(name), Optional.empty(), Optional.empty(), Optional.empty());
+	}
+
+	@Override
+	public void changePosition(int position) throws MissingPermissionsException, DiscordException, RateLimitException {
+		edit(Optional.empty(), Optional.of(position), Optional.empty(), Optional.empty());
+	}
+
+	@Override
 	public void changeUserLimit(int limit) throws MissingPermissionsException, DiscordException, RateLimitException {
 		edit(Optional.empty(), Optional.empty(), Optional.empty(), Optional.of(limit));
 	}

--- a/src/main/java/sx/blah/discord/json/requests/ChannelEditRequest.java
+++ b/src/main/java/sx/blah/discord/json/requests/ChannelEditRequest.java
@@ -34,6 +34,7 @@ public class ChannelEditRequest {
 		this.name = name;
 		this.position = position;
 		this.topic = topic;
+		this.bitrate = 8000;
 	}
 
 	public ChannelEditRequest(String name, int position, int bitrate, int user_limit) {


### PR DESCRIPTION
### Prerequisites
* [x] I have read and understand the [contribution guidelines](CONTRIBUTING.md)
* [x] This pull request follows the code style of the project
* [x] I have tested this feature thoroughly

**Issues Fixed:**
* Editing a text channel would throw DiscordException because of the default bitrate being 0 instead of 8000.
* Editing a voice channel's name or position would reset it's bitrate and user limit due to using Channel's edit instead of VoiceChannel's

### Changes Proposed in this Pull Request
* VoiceChannel now overrides changeName and changePosition from Channel to use VoiceChannel#edit
* ChannelEditRequest now has a default value of 8000 (the minimum) for bitrate to avoid errors editing text channels

...



