### PR TITLE
CloudFlare 502 detection not working for non-nginx errors

### DIFF
--- a/src/main/java/sx/blah/discord/api/internal/Requests.java
+++ b/src/main/java/sx/blah/discord/api/internal/Requests.java
@@ -143,9 +143,9 @@ public enum Requests {
 			} else if (responseCode == 502) {
 				LOGGER.trace(LogMarkers.API, "502 response on request to {}, response text: {}", request.getURI(), message); //This can be used to verify if it was cloudflare causing the 502.
 				
-				if (message.contains("cloudflare-nginx")) {
+				if (message.toLowerCase(Locale.ROOT).contains("cloudflare")) {
 					throw new DiscordException("502 error on request to " + request.getURI()
-							+ ". This is due to CloudFlare (detected \"cloudflare-nginx\" in message).");
+							+ ". This is due to CloudFlare.");
 				}
 				
 				throw new DiscordException("502 error on request to "+request.getURI()+". With response text: "+message);


### PR DESCRIPTION
### Prerequisites
* [x] I have read and understand the [contribution guidelines](CONTRIBUTING.md)
* [x] This pull request follows the code style of the project
* [x] I have tested this feature thoroughly

### Changes Proposed in this Pull Request
* Wouldn't pick up CF errors that didn't have "cloudflare-nginx" for 502s, fixed.



