### PR TITLE
Add MessageTokenizer utility

### DIFF
--- a/src/main/java/sx/blah/discord/util/MessageTokenizer.java
+++ b/src/main/java/sx/blah/discord/util/MessageTokenizer.java
@@ -57,6 +57,7 @@ public class MessageTokenizer {
 			throw new IllegalArgumentException("Amount cannot be negative!");
 
 		currentPosition += amount;
+		currentPosition = Math.min(currentPosition, content.length());
 		remaining = content.substring(currentPosition);
 
 		return currentPosition;
@@ -65,7 +66,7 @@ public class MessageTokenizer {
 	/**
 	 * Returns true if the traverser isn't at the end of the string.
 	 *
-	 * @return If we have another char to step to
+	 * @return True if we have another char to step to
 	 */
 	public boolean hasNext() {
 		return currentPosition < content.length();
@@ -74,7 +75,7 @@ public class MessageTokenizer {
 	/**
 	 * Exactly the same as {@link MessageTokenizer#hasNext()}. Returns true if there is another char to step to.
 	 *
-	 * @return If there is more to step to
+	 * @return True if there is more to step to
 	 * @see MessageTokenizer#hasNext()
 	 */
 	public boolean hasNextChar() {
@@ -94,6 +95,34 @@ public class MessageTokenizer {
 		char c = content.charAt(currentPosition);
 		stepForward(1);
 		return c;
+	}
+
+	/**
+	 * Returns true if there is another word to go to. A word is delimited by a space.
+	 *
+	 * @return True if there is another word to step to
+	 */
+	public boolean hasNextWord() {
+		int index = remaining.lastIndexOf(' ');
+		return index < remaining.length() - 2 && index > -1;
+	}
+
+	/**
+	 * Returns the next word, stepping forward the tokenizer to the next non-space character. A word is delimited by
+	 * a space.
+	 *
+	 * @return The next word
+	 */
+	public Token nextWord() {
+		if (!hasNextWord())
+			throw new IllegalStateException("No more words found!");
+
+		int indexOfSpace = remaining.indexOf(' ');
+		Token token = new Token(this, currentPosition, currentPosition + indexOfSpace);
+
+		stepForward(indexOfSpace + 1);
+
+		return token;
 	}
 
 	/**

--- a/src/main/java/sx/blah/discord/util/MessageTokenizer.java
+++ b/src/main/java/sx/blah/discord/util/MessageTokenizer.java
@@ -73,7 +73,7 @@ public class MessageTokenizer {
 	 * @return The new current position
 	 * @see MessageTokenizer#stepForward(int)
 	 */
-	public int stepForwardTo(int index) {
+	public int stepTo(int index) {
 		return stepForward(index - currentPosition);
 	}
 
@@ -190,7 +190,7 @@ public class MessageTokenizer {
 		final int start = currentPosition + matcher.start();
 		final int end = currentPosition + matcher.end() + 1;
 
-		stepForwardTo(end);
+		stepTo(end);
 
 		return new Token(this, start, end);
 	}

--- a/src/main/java/sx/blah/discord/util/MessageTokenizer.java
+++ b/src/main/java/sx/blah/discord/util/MessageTokenizer.java
@@ -184,6 +184,12 @@ public class MessageTokenizer {
 		return hasNext() && pattern.matcher(remaining).find();
 	}
 
+	/**
+	 * Returns the next occurrence of the regular expression, stepping forward the tokenizer to the next line.
+	 *
+	 * @param pattern The regex pattern
+	 * @return The token of the regex occurrence
+	 */
 	public Token nextRegex(Pattern pattern) {
 		if (!hasNextRegex(pattern))
 			throw new IllegalStateException("No more occurrences found!");

--- a/src/main/java/sx/blah/discord/util/MessageTokenizer.java
+++ b/src/main/java/sx/blah/discord/util/MessageTokenizer.java
@@ -80,6 +80,43 @@ public class MessageTokenizer {
 			content = tokenizer.getContent().substring(startIndex, endIndex);
 		}
 
+		/**
+		 * Get the tokenizer object this token is associated with.
+		 *
+		 * @return The tokenizer
+		 */
+		public MessageTokenizer getTokenizer() {
+			return tokenizer;
+		}
+
+		/**
+		 * Get the content that makes up this token.
+		 *
+		 * @return The string of content
+		 */
+		public String getContent() {
+			return content;
+		}
+
+		/**
+		 * Get the start index which is where this token starts in the tokenizer's contents.
+		 *
+		 * @return The start index
+		 */
+		public int getStartIndex() {
+			return startIndex;
+		}
+
+		/**
+		 * Get the end index which is the index at which this token terminates, exclusive. Acts like the second
+		 * parameter in
+		 * {@link String#substring(int, int)}.
+		 *
+		 * @return The end index
+		 */
+		public int getEndIndex() {
+			return endIndex;
+		}
 	}
 
 	public static abstract class MentionToken<T extends IDiscordObject<?>> extends Token {

--- a/src/main/java/sx/blah/discord/util/MessageTokenizer.java
+++ b/src/main/java/sx/blah/discord/util/MessageTokenizer.java
@@ -134,7 +134,7 @@ public class MessageTokenizer {
 		if (!hasNextWord())
 			throw new IllegalStateException("No more words found!");
 
-		int indexOfSpace = remaining.indexOf(' ');
+		int indexOfSpace = Math.min(remaining.indexOf(' '), remaining.indexOf('\n'));
 		if (indexOfSpace == -1) {
 			indexOfSpace = content.length() - currentPosition;
 		}

--- a/src/main/java/sx/blah/discord/util/MessageTokenizer.java
+++ b/src/main/java/sx/blah/discord/util/MessageTokenizer.java
@@ -1,0 +1,149 @@
+package sx.blah.discord.util;
+
+import sx.blah.discord.api.IDiscordClient;
+import sx.blah.discord.handle.obj.*;
+
+/**
+ * A utility class to traverse through a message's contents and step through tokens like mentions, characters, words,
+ * etc.
+ *
+ * @author chrislo27
+ */
+public class MessageTokenizer {
+
+	private final String content;
+	private final IDiscordClient client;
+	private int currentPosition = 0;
+
+	/**
+	 * Initialize using the message contents and client.
+	 *
+	 * @param message The message object.
+	 */
+	public MessageTokenizer(IMessage message) {
+		this(message.getClient(), message.getContent());
+	}
+
+	/**
+	 * Initialize with the string contents.
+	 *
+	 * @param content What you want to traverse
+	 * @param client  The Discord client that will be used to get objects from
+	 */
+	public MessageTokenizer(IDiscordClient client, String content) {
+		if (content == null)
+			throw new IllegalArgumentException("Content cannot be null!");
+		if (content.length() == 0)
+			throw new IllegalArgumentException("Content must have length!");
+
+		this.content = content;
+		this.client = client;
+	}
+
+	/**
+	 * Return the content that the tokenizer is traversing.
+	 *
+	 * @return
+	 */
+	public String getContent() {
+		return content;
+	}
+
+	/**
+	 * Represents a part of a message with the content and position.
+	 */
+	public static class Token {
+
+		private final MessageTokenizer tokenizer;
+		private final int startIndex;
+		private final int endIndex;
+		private final String content;
+
+		/**
+		 * A part of a message with content and position.
+		 *
+		 * @param tokenizer  The tokenizer
+		 * @param startIndex The start index of the tokenizer's contents.
+		 * @param endIndex   The end index of the tokenizer's contents, exclusive.
+		 */
+		Token(MessageTokenizer tokenizer, int startIndex, int endIndex) {
+			if (startIndex < 0 || startIndex >= tokenizer.getContent().length())
+				throw new IllegalArgumentException("Start index must be within range of content!");
+			if (endIndex <= startIndex)
+				throw new IllegalArgumentException("End index cannot be before start index!");
+			if (endIndex > tokenizer.getContent().length())
+				throw new IllegalArgumentException("End index must be within content's length!");
+
+			this.tokenizer = tokenizer;
+			this.startIndex = startIndex;
+			this.endIndex = endIndex;
+			content = tokenizer.getContent().substring(startIndex, endIndex);
+		}
+
+	}
+
+	public static abstract class MentionToken<T extends IDiscordObject<?>> extends Token {
+
+		private final T mention;
+
+		/**
+		 * A mention of any type with its content and position.
+		 *
+		 * @param tokenizer     The tokenizer
+		 * @param startIndex    The start index of the tokenizer's contents.
+		 * @param endIndex      The end index of the tokenizer's contents, exclusive.
+		 * @param mentionObject The object the mention is associated with.
+		 */
+		MentionToken(MessageTokenizer tokenizer, int startIndex, int endIndex, T mentionObject) {
+			super(tokenizer, startIndex, endIndex);
+
+			mention = mentionObject;
+		}
+	}
+
+	public static abstract class UserMentionToken<T extends IUser> extends MentionToken {
+
+		/**
+		 * A user mention with its content and position.
+		 *
+		 * @param tokenizer  The tokenizer
+		 * @param startIndex The start index of the tokenizer's contents.
+		 * @param endIndex   The end index of the tokenizer's contents, exclusive.
+		 * @param user       The user object it's associated with.
+		 */
+		UserMentionToken(MessageTokenizer tokenizer, int startIndex, int endIndex, IUser user) {
+			super(tokenizer, startIndex, endIndex, user);
+		}
+	}
+
+	public static abstract class RoleMentionToken<T extends IRole> extends MentionToken {
+
+		/**
+		 * A role mention with its content and position.
+		 *
+		 * @param tokenizer  The tokenizer
+		 * @param startIndex The start index of the tokenizer's contents.
+		 * @param endIndex   The end index of the tokenizer's contents, exclusive.
+		 * @param role       The role object it's associated with.
+		 */
+		RoleMentionToken(MessageTokenizer tokenizer, int startIndex, int endIndex, IRole role) {
+			super(tokenizer, startIndex, endIndex, role);
+		}
+	}
+
+	public static abstract class ChannelMentionToken<T extends IChannel> extends MentionToken {
+
+		/**
+		 * A channel mention with its content and position.
+		 *
+		 * @param tokenizer  The tokenizer
+		 * @param startIndex The start index of the tokenizer's contents.
+		 * @param endIndex   The end index of the tokenizer's contents, exclusive.
+		 * @param channel    The channel object it's associated with.
+		 */
+		ChannelMentionToken(MessageTokenizer tokenizer, int startIndex, int endIndex, IChannel channel) {
+			super(tokenizer, startIndex, endIndex, channel);
+		}
+	}
+
+}

--- a/src/main/java/sx/blah/discord/util/MessageTokenizer.java
+++ b/src/main/java/sx/blah/discord/util/MessageTokenizer.java
@@ -39,12 +39,15 @@ public class MessageTokenizer {
 	 *
 	 * @param content What you want to traverse
 	 * @param client  The Discord client that will be used to get objects from
+	 * @throws IllegalArgumentException If content is null, empty, or client is null
 	 */
 	public MessageTokenizer(IDiscordClient client, String content) {
 		if (content == null)
 			throw new IllegalArgumentException("Content cannot be null!");
 		if (content.length() == 0)
 			throw new IllegalArgumentException("Content must have length!");
+		if (client == null)
+			throw new IllegalArgumentException("Client cannot be null!");
 
 		this.content = content;
 		this.client = client;
@@ -173,14 +176,15 @@ public class MessageTokenizer {
 
 	/**
 	 * Returns true if an occurence of the regex pattern exists.
+	 *
 	 * @param pattern The regex pattern
 	 * @return True if there is an occurence
 	 */
-	public boolean hasNextRegex(Pattern pattern){
+	public boolean hasNextRegex(Pattern pattern) {
 		return hasNext() && pattern.matcher(remaining).find();
 	}
 
-	public Token nextRegex(Pattern pattern){
+	public Token nextRegex(Pattern pattern) {
 		if (!hasNextRegex(pattern))
 			throw new IllegalStateException("No more occurrences found!");
 

--- a/src/main/java/sx/blah/discord/util/MessageTokenizer.java
+++ b/src/main/java/sx/blah/discord/util/MessageTokenizer.java
@@ -8,7 +8,11 @@ import java.util.regex.Pattern;
 
 /**
  * A utility class to traverse through a message's contents and step through tokens like mentions, characters, words,
- * etc.
+ * etc. The tokenizer has an internal pointer of where it's at in the message. Everytime you call nextX, the internal
+ * pointer will move <b>past</b> the token it found. For example, if the string is <code>this is a string of
+ * words</code>, when {@link #nextWord()} is first called, it will return <code>this</code>, and move to the first
+ * space. Calling {@link #nextChar()} will return that space, and move to <code>i</code>, in <code>is a...</code>,
+ * and so forth.
  *
  * @author chrislo27
  */

--- a/src/main/java/sx/blah/discord/util/MessageTokenizer.java
+++ b/src/main/java/sx/blah/discord/util/MessageTokenizer.java
@@ -336,6 +336,15 @@ public class MessageTokenizer {
 
 			mention = mentionObject;
 		}
+
+		/**
+		 * Returns the object associated with the mention (IUser, IRole, IChannel, etc).
+		 *
+		 * @return The object associated with the mention
+		 */
+		public T getMentionObject() {
+			return mention;
+		}
 	}
 
 	public static class UserMentionToken extends MentionToken<IUser> {

--- a/src/main/java/sx/blah/discord/util/MessageTokenizer.java
+++ b/src/main/java/sx/blah/discord/util/MessageTokenizer.java
@@ -14,18 +14,22 @@ public class MessageTokenizer {
 	private final String content;
 	private final IDiscordClient client;
 	private int currentPosition = 0;
+	/**
+	 * The remaining substring.
+	 */
+	private String remaining;
 
 	/**
-	 * Initialize using the message contents and client.
+	 * Initializes using the message contents and client.
 	 *
-	 * @param message The message object.
+	 * @param message The message object
 	 */
 	public MessageTokenizer(IMessage message) {
 		this(message.getClient(), message.getContent());
 	}
 
 	/**
-	 * Initialize with the string contents.
+	 * Initializes with the string contents.
 	 *
 	 * @param content What you want to traverse
 	 * @param client  The Discord client that will be used to get objects from
@@ -38,15 +42,85 @@ public class MessageTokenizer {
 
 		this.content = content;
 		this.client = client;
+
+		stepForward(0);
 	}
 
 	/**
-	 * Return the content that the tokenizer is traversing.
+	 * Steps forward the current position and updates the internal remaining string.
 	 *
-	 * @return
+	 * @param amount The amount to step forward, must be zero or higher
+	 * @return The new current position
+	 */
+	public int stepForward(int amount) {
+		if (amount < 0)
+			throw new IllegalArgumentException("Amount cannot be negative!");
+
+		currentPosition += amount;
+		remaining = content.substring(currentPosition);
+
+		return currentPosition;
+	}
+
+	/**
+	 * Returns true if the traverser isn't at the end of the string.
+	 *
+	 * @return If we have another char to step to
+	 */
+	public boolean hasNext() {
+		return currentPosition < content.length();
+	}
+
+	/**
+	 * Exactly the same as {@link MessageTokenizer#hasNext()}. Returns true if there is another char to step to.
+	 *
+	 * @return If there is more to step to
+	 * @see MessageTokenizer#hasNext()
+	 */
+	public boolean hasNextChar() {
+		return hasNext();
+	}
+
+	/**
+	 * Returns the next character, stepping forward the tokenizer.
+	 *
+	 * @return The next char
+	 * @throws IllegalStateException If there aren't more chars to go to
+	 */
+	public char nextChar() {
+		if (!hasNextChar())
+			throw new IllegalStateException("Reached end of string!");
+
+		char c = content.charAt(currentPosition);
+		stepForward(1);
+		return c;
+	}
+
+	/**
+	 * Returns the content that the tokenizer is traversing.
+	 *
+	 * @return The content that is being traversed
 	 */
 	public String getContent() {
 		return content;
+	}
+
+	/**
+	 * Returns the Discord client this tokenizer uses.
+	 *
+	 * @return The Discord client
+	 */
+	public IDiscordClient getClient() {
+		return client;
+	}
+
+	/**
+	 * Returns the current position/index this tokenizer is at.
+	 *
+	 * @return The current position/index
+	 */
+	public int getCurrentPosition() {
+		return currentPosition;
 	}
 
 	/**
@@ -63,8 +137,8 @@ public class MessageTokenizer {
 		 * A part of a message with content and position.
 		 *
 		 * @param tokenizer  The tokenizer
-		 * @param startIndex The start index of the tokenizer's contents.
-		 * @param endIndex   The end index of the tokenizer's contents, exclusive.
+		 * @param startIndex The start index of the tokenizer's contents
+		 * @param endIndex   The end index of the tokenizer's contents, exclusive
 		 */
 		Token(MessageTokenizer tokenizer, int startIndex, int endIndex) {
 			if (startIndex < 0 || startIndex >= tokenizer.getContent().length())
@@ -81,7 +155,7 @@ public class MessageTokenizer {
 		}
 
 		/**
-		 * Get the tokenizer object this token is associated with.
+		 * Gets the tokenizer object this token is associated with.
 		 *
 		 * @return The tokenizer
 		 */
@@ -90,7 +164,7 @@ public class MessageTokenizer {
 		}
 
 		/**
-		 * Get the content that makes up this token.
+		 * Gets the content that makes up this token.
 		 *
 		 * @return The string of content
 		 */
@@ -99,7 +173,7 @@ public class MessageTokenizer {
 		}
 
 		/**
-		 * Get the start index which is where this token starts in the tokenizer's contents.
+		 * Gets the start index which is where this token starts in the tokenizer's contents.
 		 *
 		 * @return The start index
 		 */
@@ -127,9 +201,9 @@ public class MessageTokenizer {
 		 * A mention of any type with its content and position.
 		 *
 		 * @param tokenizer     The tokenizer
-		 * @param startIndex    The start index of the tokenizer's contents.
-		 * @param endIndex      The end index of the tokenizer's contents, exclusive.
-		 * @param mentionObject The object the mention is associated with.
+		 * @param startIndex    The start index of the tokenizer's contents
+		 * @param endIndex      The end index of the tokenizer's contents, exclusive
+		 * @param mentionObject The object the mention is associated with
 		 */
 		MentionToken(MessageTokenizer tokenizer, int startIndex, int endIndex, T mentionObject) {
 			super(tokenizer, startIndex, endIndex);
@@ -144,9 +218,9 @@ public class MessageTokenizer {
 		 * A user mention with its content and position.
 		 *
 		 * @param tokenizer  The tokenizer
-		 * @param startIndex The start index of the tokenizer's contents.
-		 * @param endIndex   The end index of the tokenizer's contents, exclusive.
-		 * @param user       The user object it's associated with.
+		 * @param startIndex The start index of the tokenizer's contents
+		 * @param endIndex   The end index of the tokenizer's contents, exclusive
+		 * @param user       The user object it's associated with
 		 */
 		UserMentionToken(MessageTokenizer tokenizer, int startIndex, int endIndex, IUser user) {
 			super(tokenizer, startIndex, endIndex, user);
@@ -159,9 +233,9 @@ public class MessageTokenizer {
 		 * A role mention with its content and position.
 		 *
 		 * @param tokenizer  The tokenizer
-		 * @param startIndex The start index of the tokenizer's contents.
-		 * @param endIndex   The end index of the tokenizer's contents, exclusive.
-		 * @param role       The role object it's associated with.
+		 * @param startIndex The start index of the tokenizer's contents
+		 * @param endIndex   The end index of the tokenizer's contents, exclusive
+		 * @param role       The role object it's associated with
 		 */
 		RoleMentionToken(MessageTokenizer tokenizer, int startIndex, int endIndex, IRole role) {
 			super(tokenizer, startIndex, endIndex, role);
@@ -174,9 +248,9 @@ public class MessageTokenizer {
 		 * A channel mention with its content and position.
 		 *
 		 * @param tokenizer  The tokenizer
-		 * @param startIndex The start index of the tokenizer's contents.
-		 * @param endIndex   The end index of the tokenizer's contents, exclusive.
-		 * @param channel    The channel object it's associated with.
+		 * @param startIndex The start index of the tokenizer's contents
+		 * @param endIndex   The end index of the tokenizer's contents, exclusive
+		 * @param channel    The channel object it's associated with
 		 */
 		ChannelMentionToken(MessageTokenizer tokenizer, int startIndex, int endIndex, IChannel channel) {
 			super(tokenizer, startIndex, endIndex, channel);

--- a/src/main/java/sx/blah/discord/util/MessageTokenizer.java
+++ b/src/main/java/sx/blah/discord/util/MessageTokenizer.java
@@ -192,7 +192,7 @@ public class MessageTokenizer {
 		if (!matcher.find())
 			throw new IllegalStateException("Couldn't find any matches!");
 		final int start = currentPosition + matcher.start();
-		final int end = currentPosition + matcher.end() + 1;
+		final int end = currentPosition + matcher.end();
 
 		stepTo(end);
 

--- a/src/main/java/sx/blah/discord/util/MessageTokenizer.java
+++ b/src/main/java/sx/blah/discord/util/MessageTokenizer.java
@@ -284,11 +284,17 @@ public class MessageTokenizer {
 		 */
 		Token(MessageTokenizer tokenizer, int startIndex, int endIndex) {
 			if (startIndex < 0 || startIndex >= tokenizer.getContent().length())
-				throw new IllegalArgumentException("Start index must be within range of content!");
+				throw new IllegalArgumentException("Start index must be within range of content! (Got " + startIndex +
+						" for startIndex, must be between 0 and " + (tokenizer.getContent().length() - 1) +
+						", inclusive)");
 			if (endIndex <= startIndex)
-				throw new IllegalArgumentException("End index cannot be before start index!");
+				throw new IllegalArgumentException(
+						"End index cannot be before or at start index! (Start index is " + startIndex + ", got " +
+								endIndex + ")");
 			if (endIndex > tokenizer.getContent().length())
-				throw new IllegalArgumentException("End index must be within content's length!");
+				throw new IllegalArgumentException(
+						"End index must be within content's length! (End index is " + endIndex + ", length is " +
+								tokenizer.getContent().length() + ")");
 
 			this.tokenizer = tokenizer;
 			this.startIndex = startIndex;


### PR DESCRIPTION
### Prerequisites
* [X] I have read and understand the [contribution guidelines](CONTRIBUTING.md)
* [X] This pull request follows the code style of the project
* [X] I have tested this feature thoroughly

The MessageTokenizer allows you to take an IMessage (or IDiscordClient + String) and do `hasNextX` and `nextX` methods on it. The supported tokens are characters, words, lines, mentions (role, user, channel), and a regex expression (Pattern class). For example, if you wanted to get the first mention after a word, you would do:

```java
MessageTokenizer tokenizer = new MessageTokenizer(message);
if (tokenizer.hasNextWord()) {
    // get the word, and advance the tokenizer past it
    String firstWord = tokenizer.nextWord();
    if (tokenizer.hasNextMention()) {
        // get the mention, (and advance the tokenizer past it)
        MentionToken token = tokenizer.nextMention();
        // get the object which will be a type of the mention type (IUser, IRole, IChannel)
        IDiscordObject obj = token.getMentionObject();
    }
}
```

You can also use regex using the `hasRegex` and `nextRegex` methods. The mention methods use it (`<((@[!&]?)|#)\d+>`).

### Changes Proposed in this Pull Request
* Implementation of the MessageTokenizer which was an idea by @austinv11 during a chat in the Discord4J Discord server
