### PR TITLE
Adds getChannelMentions to IMessage

### DIFF
--- a/src/main/java/sx/blah/discord/api/internal/DiscordUtils.java
+++ b/src/main/java/sx/blah/discord/api/internal/DiscordUtils.java
@@ -358,6 +358,8 @@ public class DiscordUtils {
 			message.setTimestamp(convertFromTimestamp(json.timestamp));
 			message.setEditedTimestamp(json.edited_timestamp == null ? null : convertFromTimestamp(json.edited_timestamp));
 			message.setPinned(json.pinned);
+			message.setChannelMentions();
+
 			return message;
 		} else
 			return new Message(client, json.id, json.content, getUserFromJSON(client, json.author),

--- a/src/main/java/sx/blah/discord/handle/impl/obj/Message.java
+++ b/src/main/java/sx/blah/discord/handle/impl/obj/Message.java
@@ -113,16 +113,7 @@ public class Message implements IMessage {
 		this.isPinned = pinned;
 		this.channelMentions = new ArrayList<>();
 
-		Matcher matcher = CHANNEL_PATTERN.matcher(content);
-
-		while (matcher.find()) {
-			String mentionedID = matcher.group(1);
-			IChannel mentioned = channel.getGuild().getChannelByID(mentionedID);
-
-			if (mentioned != null) {
-				channelMentions.add(mentioned);
-			}
-		}
+		setChannelMentions();
 	}
 
 	@Override
@@ -148,6 +139,23 @@ public class Message implements IMessage {
 	public void setMentions(List<String> mentions, List<String> roleMentions) {
 		this.mentions = mentions;
 		this.roleMentions = roleMentions;
+	}
+
+	/**
+	 * Populates the channel mention list.
+	 */
+	public void setChannelMentions() {
+		channelMentions.clear();
+		Matcher matcher = CHANNEL_PATTERN.matcher(content);
+
+		while (matcher.find()) {
+			String mentionedID = matcher.group(1);
+			IChannel mentioned = channel.getGuild().getChannelByID(mentionedID);
+
+			if (mentioned != null) {
+				channelMentions.add(mentioned);
+			}
+		}
 	}
 
 	/**

--- a/src/main/java/sx/blah/discord/handle/impl/obj/Message.java
+++ b/src/main/java/sx/blah/discord/handle/impl/obj/Message.java
@@ -3,24 +3,23 @@ package sx.blah.discord.handle.impl.obj;
 import org.apache.http.entity.StringEntity;
 import org.apache.http.message.BasicNameValuePair;
 import sx.blah.discord.Discord4J;
+import sx.blah.discord.api.IDiscordClient;
 import sx.blah.discord.api.internal.DiscordClientImpl;
 import sx.blah.discord.api.internal.DiscordEndpoints;
-import sx.blah.discord.util.DiscordException;
-import sx.blah.discord.api.IDiscordClient;
-import sx.blah.discord.util.LogMarkers;
-import sx.blah.discord.util.MissingPermissionsException;
 import sx.blah.discord.api.internal.DiscordUtils;
-import sx.blah.discord.handle.impl.events.MessageUpdateEvent;
-import sx.blah.discord.handle.obj.*;
 import sx.blah.discord.api.internal.json.requests.MessageRequest;
 import sx.blah.discord.api.internal.json.responses.MessageResponse;
+import sx.blah.discord.handle.impl.events.MessageUpdateEvent;
+import sx.blah.discord.handle.obj.*;
+import sx.blah.discord.util.DiscordException;
+import sx.blah.discord.util.LogMarkers;
+import sx.blah.discord.util.MissingPermissionsException;
 import sx.blah.discord.util.RateLimitException;
 
 import java.time.LocalDateTime;
-import java.util.EnumSet;
-import java.util.List;
-import java.util.Objects;
-import java.util.Optional;
+import java.util.*;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 public class Message implements IMessage {
@@ -82,9 +81,19 @@ public class Message implements IMessage {
 	protected volatile boolean isPinned;
 
 	/**
+	 * The list of channels mentioned by this message.
+	 */
+	protected final List<IChannel> channelMentions;
+
+	/**
 	 * The client that created this object.
 	 */
 	protected final IDiscordClient client;
+
+	/**
+	 * The pattern for matching channel mentions.
+	 */
+	private static final Pattern CHANNEL_PATTERN = Pattern.compile("<#([0-9]+)>");
 
 	public Message(IDiscordClient client, String id, String content, IUser user, IChannel channel,
 				   LocalDateTime timestamp, LocalDateTime editedTimestamp, boolean mentionsEveryone,
@@ -102,6 +111,18 @@ public class Message implements IMessage {
 		this.attachments = attachments;
 		this.mentionsEveryone = mentionsEveryone;
 		this.isPinned = pinned;
+		this.channelMentions = new ArrayList<>();
+
+		Matcher matcher = CHANNEL_PATTERN.matcher(content);
+
+		while (matcher.find()) {
+			String mentionedID = matcher.group(1);
+			IChannel mentioned = channel.getGuild().getChannelByID(mentionedID);
+
+			if (mentioned != null) {
+				channelMentions.add(mentioned);
+			}
+		}
 	}
 
 	@Override
@@ -172,7 +193,7 @@ public class Message implements IMessage {
 		if (mentionsEveryone)
 			return channel.getGuild().getUsers();
 		return mentions.stream()
-				.map(m -> client.getUserByID(m))
+				.map(client::getUserByID)
 				.collect(Collectors.toList());
 	}
 
@@ -181,6 +202,11 @@ public class Message implements IMessage {
 		return roleMentions.stream()
 				.map(m -> getGuild().getRoleByID(m))
 				.collect(Collectors.toList());
+	}
+
+	@Override
+	public List<IChannel> getChannelMentions() {
+		return channelMentions;
 	}
 
 	@Override
@@ -297,9 +323,8 @@ public class Message implements IMessage {
 
 	@Override
 	public IMessage copy() {
-		Message message = new Message(client, id, content, author, channel, timestamp, editedTimestamp,
+		return new Message(client, id, content, author, channel, timestamp, editedTimestamp,
 				mentionsEveryone, mentions, roleMentions, attachments, isPinned);
-		return message;
 	}
 
 	@Override
@@ -324,9 +349,6 @@ public class Message implements IMessage {
 
 	@Override
 	public boolean equals(Object other) {
-		if (other == null)
-			return false;
-
-		return this.getClass().isAssignableFrom(other.getClass()) && ((IMessage) other).getID().equals(getID());
+		return other != null && this.getClass().isAssignableFrom(other.getClass()) && ((IMessage) other).getID().equals(getID());
 	}
 }

--- a/src/main/java/sx/blah/discord/handle/obj/IMessage.java
+++ b/src/main/java/sx/blah/discord/handle/obj/IMessage.java
@@ -61,6 +61,13 @@ public interface IMessage extends IDiscordObject<IMessage> {
 	List<IRole> getRoleMentions();
 
 	/**
+	 * Gets the channels mentioned in this message.
+	 *
+	 * @return The channels mentioned.
+	 */
+	List<IChannel> getChannelMentions();
+
+	/**
 	 * Gets the attachments in this message.
 	 *
 	 * @return The attachments.


### PR DESCRIPTION
### Prerequisites
* [x] I have read and understand the [contribution guidelines](CONTRIBUTING.md)
* [x] This pull request follows the code style of the project
* [x] I have tested this feature thoroughly

**Issues Fixed:** N/A

### Changes Proposed in this Pull Request
* Adds a method to IMessage allowing you to get the channel mentions in a message, since for whatever reason, Discord does not send these out like it sends out role and user mentions.

Also cleans up some things in Message, shout-out to IntelliJ