### PR TITLE
Null check on content when getting channel mentions

### DIFF
--- a/src/main/java/sx/blah/discord/handle/impl/obj/Message.java
+++ b/src/main/java/sx/blah/discord/handle/impl/obj/Message.java
@@ -145,15 +145,17 @@ public class Message implements IMessage {
 	 * Populates the channel mention list.
 	 */
 	public void setChannelMentions() {
-		channelMentions.clear();
-		Matcher matcher = CHANNEL_PATTERN.matcher(content);
+		if (content != null) {
+			channelMentions.clear();
+			Matcher matcher = CHANNEL_PATTERN.matcher(content);
 
-		while (matcher.find()) {
-			String mentionedID = matcher.group(1);
-			IChannel mentioned = channel.getGuild().getChannelByID(mentionedID);
+			while (matcher.find()) {
+				String mentionedID = matcher.group(1);
+				IChannel mentioned = channel.getGuild().getChannelByID(mentionedID);
 
-			if (mentioned != null) {
-				channelMentions.add(mentioned);
+				if (mentioned != null) {
+					channelMentions.add(mentioned);
+				}
 			}
 		}
 	}


### PR DESCRIPTION
### Prerequisites
* [x] I have read and understand the [contribution guidelines](CONTRIBUTING.md)
* [x] This pull request follows the code style of the project
* [x] [I have tested this feature thoroughly](https://u.pomf.is/haudpw.png)

**Issues Fixed:** #101 [would crash when there is an embed link](https://u.pomf.is/idsryj.png)

### Changes Proposed in this Pull Request
* Everything in setChannelMentions is now wrapped with a null check

Content is null when something is embedded, I forgot that was a thing
kotlin spoils me™