### PR TITLE
Reconnect fix, logout fix, and allow DiscordDisconnectedEvent to fire

### DIFF
--- a/src/main/java/sx/blah/discord/api/events/EventDispatcher.java
+++ b/src/main/java/sx/blah/discord/api/events/EventDispatcher.java
@@ -3,6 +3,7 @@ package sx.blah.discord.api.events;
 import net.jodah.typetools.TypeResolver;
 import sx.blah.discord.Discord4J;
 import sx.blah.discord.api.IDiscordClient;
+import sx.blah.discord.handle.impl.events.DiscordDisconnectedEvent;
 import sx.blah.discord.util.LogMarkers;
 
 import java.lang.reflect.InvocationTargetException;
@@ -266,7 +267,7 @@ public class EventDispatcher {
 	 * @param event The event.
 	 */
 	public synchronized void dispatch(Event event) {
-		if (client.isReady()) {
+		if (client.isReady() || event instanceof DiscordDisconnectedEvent) {
 			eventExecutor.submit(() -> {
 				Discord4J.LOGGER.trace(LogMarkers.EVENTS, "Dispatching event of type {}", event.getClass().getSimpleName());
 				event.client = client;

--- a/src/main/java/sx/blah/discord/api/internal/DiscordWS.java
+++ b/src/main/java/sx/blah/discord/api/internal/DiscordWS.java
@@ -182,12 +182,13 @@ public class DiscordWS {
 				|| reason == DiscordDisconnectedEvent.Reason.INIT_ERROR
 				|| reason == DiscordDisconnectedEvent.Reason.INVALID_SESSION
 				|| (reason == DiscordDisconnectedEvent.Reason.RECONNECTION_FAILED
-					&& reconnectAttempts.get() <= maxReconnectAttempts))) {
+				&& reconnectAttempts.get() <= maxReconnectAttempts))) {
 
 			isReconnecting.set(true);
 
 			if (reconnectAttempts.incrementAndGet() > maxReconnectAttempts) {
 				Discord4J.LOGGER.error(LogMarkers.WEBSOCKET, "Reconnection was attempted too many times ({} attempts)", reconnectAttempts);
+				isReconnecting.set(false);//When reconnect has timed out then allow the bot to fully disconnect
 				disconnect(DiscordDisconnectedEvent.Reason.RECONNECTION_FAILED);
 				return;
 			} else {
@@ -216,27 +217,26 @@ public class DiscordWS {
 				}
 			}
 		}
-
-		executorService.shutdownNow();
-
-		startingUp.set(false);
-		sentPing.set(false);
-		isReconnecting.set(false);
-		missedPingCount.set(0);
 		client.dispatcher.dispatch(new DiscordDisconnectedEvent(reason));
-		client.ws = null;
-		for (DiscordVoiceWS vws : client.voiceConnections.values()) { //Ensures that voice connections are closed.
-			VoiceDisconnectedEvent.Reason voiceReason;
-			try {
-				voiceReason = VoiceDisconnectedEvent.Reason.valueOf(reason.toString());
-			} catch (IllegalArgumentException e) {
-				voiceReason = VoiceDisconnectedEvent.Reason.UNKNOWN;
+		if(!isReconnecting.get()) { //Doesn't let the bot actually disconnect unless reconnecting has failed
+			startingUp.set(false);
+			sentPing.set(false);
+			missedPingCount.set(0);
+			client.ws = null;
+			for (DiscordVoiceWS vws : client.voiceConnections.values()) { //Ensures that voice connections are closed.
+				VoiceDisconnectedEvent.Reason voiceReason;
+				try {
+					voiceReason = VoiceDisconnectedEvent.Reason.valueOf(reason.toString());
+				} catch (IllegalArgumentException e) {
+					voiceReason = VoiceDisconnectedEvent.Reason.UNKNOWN;
+				}
+				vws.disconnect(voiceReason);
 			}
-			vws.disconnect(voiceReason);
-		}
-		Runtime.getRuntime().removeShutdownHook(shutdownHook);
-		if (reason != DiscordDisconnectedEvent.Reason.INIT_ERROR) {
-			session.close();
+			Runtime.getRuntime().removeShutdownHook(shutdownHook);
+			executorService.shutdownNow();
+			if (reason != DiscordDisconnectedEvent.Reason.INIT_ERROR) {
+				session.close();
+			}
 		}
 	}
 
@@ -1122,7 +1122,9 @@ public class DiscordWS {
 	@OnWebSocketClose
 	public void onClose(Session session, int code, String reason) {
 		Discord4J.LOGGER.debug(LogMarkers.WEBSOCKET, "Websocket disconnected. Exit Code: {}. Reason: {}.", code, reason);
-		disconnect(DiscordDisconnectedEvent.Reason.UNKNOWN);
+		if(isConnected.get()) { //Prevents disconnect from being called multiple times
+			disconnect(DiscordDisconnectedEvent.Reason.UNKNOWN);
+		}
 	}
 
 	@OnWebSocketError


### PR DESCRIPTION
### Prerequisites
* [x] I have read and understood the [contribution guidelines](CONTRIBUTING.md)
* [x] This pull request follows the code style of the project
* [x] I have tested this feature thoroughly

**Issues Fixed:** [The issues fixed by this pull request]
* Preventing the session from closing after a successful reconnect, as well as during reconnect, which allows the bot to reconnect successfully. This was caused because after a successful reconnect there was nothing preventing it from continuing to disconnect, adding the if statement on line 221 prevents that from happening
* Allows the DiscordDisconnectedEvent to fire when disconnected (Found by theIglooo)
* Prevents onClose from calling disconnect when isConnected is set to false preventing a reconnect attempt on logout

### Changes Proposed in this Pull Request
* Preventing the session from closing after a successful reconnect also allows for reconnect to work when the disconnect is due to internet outage. Ex. the bot can reconnect after unplugging Ethernet cable and plugging it back in after a minuet

...