### PR TITLE
Fix the CloudFlare handling in the RequestBuffer

### DIFF
--- a/src/main/java/sx/blah/discord/api/internal/Requests.java
+++ b/src/main/java/sx/blah/discord/api/internal/Requests.java
@@ -13,6 +13,7 @@ import org.apache.http.util.EntityUtils;
 import sx.blah.discord.Discord4J;
 import sx.blah.discord.api.IDiscordClient;
 import sx.blah.discord.api.internal.json.responses.RateLimitResponse;
+import sx.blah.discord.util.CloudFlareException;
 import sx.blah.discord.util.DiscordException;
 import sx.blah.discord.util.RateLimitException;
 import sx.blah.discord.util.LogMarkers;
@@ -122,8 +123,9 @@ public class Requests {
 		 *
 		 * @throws RateLimitException
 		 * @throws DiscordException
+		 * @throws CloudFlareException
 		 */
-		public String makeRequest(String url, BasicNameValuePair... headers) throws RateLimitException, DiscordException {
+		public String makeRequest(String url, BasicNameValuePair... headers) throws RateLimitException, DiscordException, CloudFlareException {
 			try {
 				HttpUriRequest request = this.requestClass.getConstructor(String.class).newInstance(url);
 				for (BasicNameValuePair header : headers) {
@@ -147,8 +149,9 @@ public class Requests {
 		 *
 		 * @throws RateLimitException
 		 * @throws DiscordException
+		 * @throws CloudFlareException
 		 */
-		public String makeRequest(String url, HttpEntity entity, BasicNameValuePair... headers) throws RateLimitException, DiscordException {
+		public String makeRequest(String url, HttpEntity entity, BasicNameValuePair... headers) throws RateLimitException, DiscordException, CloudFlareException {
 			try {
 				if (HttpEntityEnclosingRequestBase.class.isAssignableFrom(this.requestClass)) {
 					HttpEntityEnclosingRequestBase request = (HttpEntityEnclosingRequestBase)
@@ -168,7 +171,7 @@ public class Requests {
 			return null;
 		}
 
-		private String request(HttpUriRequest request) throws DiscordException, RateLimitException {
+		private String request(HttpUriRequest request) throws DiscordException, RateLimitException, CloudFlareException {
 			if (globalRetryAfter.get() != -1) {
 				if (System.currentTimeMillis() > globalRetryAfter.get())
 					globalRetryAfter.set(-1);
@@ -216,7 +219,7 @@ public class Requests {
 					LOGGER.trace(LogMarkers.API, "502 response on request to {}, response text: {}", request.getURI(), message); //This can be used to verify if it was cloudflare causing the 502.
 
 					if (message.toLowerCase(Locale.ROOT).contains("cloudflare")) {
-						throw new DiscordException("502 error on request to " + request.getURI()
+						throw new CloudFlareException("502 error on request to " + request.getURI()
 								+ ". This is due to CloudFlare.");
 					}
 

--- a/src/main/java/sx/blah/discord/util/CloudFlareException.java
+++ b/src/main/java/sx/blah/discord/util/CloudFlareException.java
@@ -2,8 +2,6 @@ package sx.blah.discord.util;
 
 /**
  * In case of a CloudFlare interruption this exception gets thrown
- * <br>
- * Created by Arsen on 22.9.16..
  */
 public class CloudFlareException extends Exception {
 	private String message;

--- a/src/main/java/sx/blah/discord/util/CloudFlareException.java
+++ b/src/main/java/sx/blah/discord/util/CloudFlareException.java
@@ -1,0 +1,29 @@
+package sx.blah.discord.util;
+
+/**
+ * In case of a CloudFlare interruption this exception gets thrown
+ * <br>
+ * Created by Arsen on 22.9.16..
+ */
+public class CloudFlareException extends Exception {
+	private String message;
+
+	/**
+	 * Creates a new CloudFlareException
+	 *
+	 * @param message The error message
+	 */
+	public CloudFlareException(String message) {
+		super(message);
+		this.message = message;
+	}
+
+	/**
+	 * This gets the error message sent by Discord.
+	 *
+	 * @return The error message.
+	 */
+	public String getErrorMessage() {
+		return message;
+	}
+}

--- a/src/main/java/sx/blah/discord/util/LogMarkers.java
+++ b/src/main/java/sx/blah/discord/util/LogMarkers.java
@@ -59,7 +59,12 @@ public enum LogMarkers implements Marker {
 	 * The marker for websocket keepalive actions.
 	 * It is a child of {@link #WEBSOCKET} and {@link #VOICE_WEBSOCKET}.
 	 */
-	KEEPALIVE(WEBSOCKET, VOICE_WEBSOCKET);
+	KEEPALIVE(WEBSOCKET, VOICE_WEBSOCKET),
+	/**
+	 * The marker for all websocket-related logging.
+	 * It is a child of {@link #API}.
+	 */
+	CLOUDFLARE(WEBSOCKET);
 
 	final Marker marker;
 

--- a/src/main/java/sx/blah/discord/util/LogMarkers.java
+++ b/src/main/java/sx/blah/discord/util/LogMarkers.java
@@ -59,12 +59,7 @@ public enum LogMarkers implements Marker {
 	 * The marker for websocket keepalive actions.
 	 * It is a child of {@link #WEBSOCKET} and {@link #VOICE_WEBSOCKET}.
 	 */
-	KEEPALIVE(WEBSOCKET, VOICE_WEBSOCKET),
-	/**
-	 * The marker for all websocket-related logging.
-	 * It is a child of {@link #API}.
-	 */
-	CLOUDFLARE(WEBSOCKET);
+	KEEPALIVE(WEBSOCKET, VOICE_WEBSOCKET);
 
 	final Marker marker;
 

--- a/src/main/java/sx/blah/discord/util/RequestBuffer.java
+++ b/src/main/java/sx/blah/discord/util/RequestBuffer.java
@@ -217,7 +217,7 @@ public class RequestBuffer {
 					timeForNextRequest = System.currentTimeMillis()+e.getRetryDelay();
 					bucket = e.getMethod();
 				} catch (CloudFlareException e){
-					Discord4J.LOGGER.debug(LogMarkers.CLOUDFLARE, "A CloudFlare exception has occured and a request will be re-attempted!", e);
+					Discord4J.LOGGER.debug(LogMarkers.UTIL, "A CloudFlare exception has occured and a request will be re-attempted!", e);
 					return tryAgain();
 				}
 			}


### PR DESCRIPTION
### Prerequisites
* [x] I have read and understood the [contribution guidelines](CONTRIBUTING.md)
* [x] This pull request follows the code style of the project
* [x] I have tested this feature thoroughly

**Issues Fixed:** A CloudFlare caused 502 would usualy cancel the request, now it will tryAgain() the request.

### Changes Proposed in this Pull Request
* Add a CloudFlare Exception
* Make the above mentioned CloudFlare exception invoke a return tryAgain() in the RequestBuffer class.