### PR TITLE
Add 'ignoreCase' parameter to ByName methods in IGuild

### DIFF
--- a/src/main/java/sx/blah/discord/handle/impl/obj/Guild.java
+++ b/src/main/java/sx/blah/discord/handle/impl/obj/Guild.java
@@ -187,24 +187,50 @@ public class Guild implements IGuild {
 
 	@Override
 	public List<IChannel> getChannelsByName(String name) {
-		return channels.stream().filter((channel) -> channel.getName().equals(name)).collect(Collectors.toList());
+		return getChannelsByName(name, false);
+	}
+	
+	@Override
+	public List<IChannel> getChannelsByName(String name, boolean ignoreCase) {
+		return channels.stream()
+				.filter((channel) ->
+					(ignoreCase) ? channel.getName().equalsIgnoreCase(name) : channel.getName().equals(name)
+				)
+				.collect(Collectors.toList());
 	}
 
 	@Override
 	public List<IVoiceChannel> getVoiceChannelsByName(String name) {
-		return voiceChannels.stream().filter((channel) -> channel.getName().equals(name)).collect(Collectors.toList());
+		return getVoiceChannelsByName(name, false);
+	}
+	
+	@Override
+	public List<IVoiceChannel> getVoiceChannelsByName(String name, boolean ignoreCase) {
+		return voiceChannels.stream()
+				.filter((channel) ->
+					(ignoreCase) ? channel.getName().equalsIgnoreCase(name) : channel.getName().equals(name)
+				)
+				.collect(Collectors.toList());
 	}
 
 	@Override
-	public List<IUser> getUsersByName(String name) {
-		return getUsersByName(name, true);
+	public List<IUser> getUsersByName(String name, boolean includeNicknames, boolean ignoreCase) {
+		return users.stream()
+				.filter((user) ->
+					(ignoreCase) ? user.getName().equalsIgnoreCase(name) || (includeNicknames && user.getNicknameForGuild(this).orElse("").equalsIgnoreCase(name))
+						: user.getName().equals(name) || (includeNicknames && user.getNicknameForGuild(this).orElse("").equals(name))
+				)
+				.collect(Collectors.toList());
 	}
-
+	
 	@Override
 	public List<IUser> getUsersByName(String name, boolean includeNicknames) {
-		return users.stream().filter((user) -> user.getName().equals(name)
-				|| (includeNicknames && user.getNicknameForGuild(this).orElse("").equals(name)))
-				.collect(Collectors.toList());
+		return getUsersByName(name, includeNicknames, false);
+	}
+	
+	@Override
+	public List<IUser> getUsersByName(String name) {
+		return getUsersByName(name, true, false);
 	}
 	
 	@Override
@@ -282,10 +308,9 @@ public class Guild implements IGuild {
 	@Override
 	public List<IRole> getRolesByName(String name, boolean ignoreCase) {
 		return roles.stream()
-				.filter((role) -> {
-					if(ignoreCase) return role.getName().equalsIgnoreCase(name);
-					else return role.getName().equals(name);
-				})
+				.filter((role) -> 
+					(ignoreCase) ? role.getName().equalsIgnoreCase(name) : role.getName().equals(name)
+				)
 				.collect(Collectors.toList());
 	}
 	

--- a/src/main/java/sx/blah/discord/handle/impl/obj/Guild.java
+++ b/src/main/java/sx/blah/discord/handle/impl/obj/Guild.java
@@ -280,8 +280,18 @@ public class Guild implements IGuild {
 	}
 
 	@Override
+	public List<IRole> getRolesByName(String name, boolean ignoreCase) {
+		return roles.stream()
+				.filter((role) -> {
+					if(ignoreCase) return role.getName().equalsIgnoreCase(name);
+					else return role.getName().equals(name);
+				})
+				.collect(Collectors.toList());
+	}
+	
+	@Override
 	public List<IRole> getRolesByName(String name) {
-		return roles.stream().filter((role) -> role.getName().equals(name)).collect(Collectors.toList());
+		return getRolesByName(name, false);
 	}
 
 	@Override

--- a/src/main/java/sx/blah/discord/handle/obj/IGuild.java
+++ b/src/main/java/sx/blah/discord/handle/obj/IGuild.java
@@ -149,6 +149,14 @@ public interface IGuild extends IDiscordObject<IGuild> {
 
 	/**
 	 * This finds all the roles which has the same name as the provided one.
+	 * @param name The name to search for.
+	 * @param ignoreCase Whether or not to ignore the casing in the role's name.
+	 * @return The roles with a matching name.
+	 */
+	List<IRole> getRolesByName(String name, boolean ignoreCase);
+	
+	/**
+	 * This finds all the roles which has the same name as the provided one.
 	 *
 	 * @param name The name to search for.
 	 * @return The roles with a matching name.

--- a/src/main/java/sx/blah/discord/handle/obj/IGuild.java
+++ b/src/main/java/sx/blah/discord/handle/obj/IGuild.java
@@ -78,10 +78,28 @@ public interface IGuild extends IDiscordObject<IGuild> {
 	 * Gets all the channels which has a name matching the provided one.
 	 *
 	 * @param name The name to search for.
+	 * @param ignoreCase Whether to ignore the casing in the channel's name.
+	 * @return The list of matching channels.
+	 */
+	List<IChannel> getChannelsByName(String name, boolean ignoreCase);
+	
+	/**
+	 * Gets all the channels which has a name matching the provided one.
+	 *
+	 * @param name The name to search for.
 	 * @return The list of matching channels.
 	 */
 	List<IChannel> getChannelsByName(String name);
 
+	/**
+	 * Gets all the voice channels which has a name matching the provided one.
+	 *
+	 * @param name The name to search for.
+	 * @param ignoreCase Whether to ignore the casing in the voice channel's name.
+	 * @return The list of matching channels.
+	 */
+	List<IVoiceChannel> getVoiceChannelsByName(String name, boolean ignoreCase);
+	
 	/**
 	 * Gets all the voice channels which has a name matching the provided one.
 	 *
@@ -91,14 +109,16 @@ public interface IGuild extends IDiscordObject<IGuild> {
 	List<IVoiceChannel> getVoiceChannelsByName(String name);
 
 	/**
-	 * Gets all the users which have a display name (i.e. nickname if present else discord name) which matches the
-	 * provided name. This is effectively the same as #getUsersByName(name, true).
+	 * Gets all the users which have a name which matches the.
+	 * provided name.
 	 *
 	 * @param name The name to search for.
+	 * @param includeNicknames Whether to check nicknames in addition to normal names.
+	 * @param ignoreCase Whether to ignore the casing in the voice channel's name.
 	 * @return The list of matching users.
 	 */
-	List<IUser> getUsersByName(String name);
-
+	List<IUser> getUsersByName(String name, boolean includeNicknames, boolean ignoreCase);
+	
 	/**
 	 * Gets all the users which have a name which matches the.
 	 * provided name.
@@ -108,6 +128,15 @@ public interface IGuild extends IDiscordObject<IGuild> {
 	 * @return The list of matching users.
 	 */
 	List<IUser> getUsersByName(String name, boolean includeNicknames);
+	
+	/**
+	 * Gets all the users which have a display name (i.e. nickname if present else discord name) which matches the
+	 * provided name. This is effectively the same as #getUsersByName(name, true).
+	 *
+	 * @param name The name to search for.
+	 * @return The list of matching users.
+	 */
+	List<IUser> getUsersByName(String name);
 	
 	/**
 	 * Gets all the users who have the provided role.
@@ -150,7 +179,7 @@ public interface IGuild extends IDiscordObject<IGuild> {
 	/**
 	 * This finds all the roles which has the same name as the provided one.
 	 * @param name The name to search for.
-	 * @param ignoreCase Whether or not to ignore the casing in the role's name.
+	 * @param ignoreCase Whether to ignore the casing in the role's name.
 	 * @return The roles with a matching name.
 	 */
 	List<IRole> getRolesByName(String name, boolean ignoreCase);


### PR DESCRIPTION
* Allows you to specify whether or not you'd like to ignore the casing
of the role's name. Defaults to `false` if not specified.