### PR TITLE
Make CloudFlare blocked requests be re-made

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,4 +21,3 @@ dependency-reduced-pom.xml
 Roadmap.md
 modules/
 bin/
-/UpdateForks.sh

--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ dependency-reduced-pom.xml
 Roadmap.md
 modules/
 bin/
+/UpdateForks.sh

--- a/src/main/java/sx/blah/discord/api/internal/Requests.java
+++ b/src/main/java/sx/blah/discord/api/internal/Requests.java
@@ -216,10 +216,9 @@ public class Requests {
 					LOGGER.trace(LogMarkers.API, "502 response on request to {}, response text: {}", request.getURI(), message); //This can be used to verify if it was cloudflare causing the 502.
 
 					if (message.toLowerCase(Locale.ROOT).contains("cloudflare")) {
-						throw new DiscordException("502 error on request to " + request.getURI()
-								+ ". This is due to CloudFlare.");
+						LOGGER.debug(LogMarkers.API, "Retrying the request due to CloudFlare interruption!");
+						return request(request);
 					}
-
 					throw new DiscordException("502 error on request to "+request.getURI()+". With response text: "+message);
 				} else if ((responseCode < 200 || responseCode > 299) && responseCode != 429) {
 					throw new DiscordException("Error on request to "+request.getURI()+". Received response code "+responseCode+". With response text: "+message);


### PR DESCRIPTION
### Prerequisites
* [x] I have read and understood the [contribution guidelines](CONTRIBUTING.md)
* [x] This pull request follows the code style of the project
* [x] I have tested this feature thoroughly

**Issues Fixed:** A CloudFlare caused 502 would usually cancel and skip that request, now it is more robust by re trying the request.

### Changes Proposed in this Pull Request
* When a CloudFlare interruption occurs, instead of throwing an exception, we re make the same exact request