### PR TITLE
Add default getResponseTime, add getAverageResponseTime

### DIFF
--- a/src/main/java/sx/blah/discord/api/IDiscordClient.java
+++ b/src/main/java/sx/blah/discord/api/IDiscordClient.java
@@ -314,13 +314,27 @@ public interface IDiscordClient {
 	IGuild createGuild(String name, IRegion region, Image icon) throws RateLimitException, DiscordException;
 
 	/**
-	 * Gets the latest response time by the discord websocket to a ping.
+	 * Gets the latest response time by the Discord websocket from a ping.
 	 *
-	 * @param shard The shard's websocket you ar3e getting the response time of.
+	 * @param shard The shard's websocket you are getting the response time of.
 	 *
 	 * @return The response time (in ms).
 	 */
 	long getResponseTime(int shard);
+
+	/**
+	 * Gets the latest response time by the Discord websocket (shard 0) from a ping.
+	 *
+	 * @return The response time (in ms).
+	 */
+	long getResponseTime();
+
+	/**
+	 * Gets the average response time by all shards from a ping.
+	 *
+	 * @return The average response time (in ms).
+	 */
+	long getAverageResponseTime();
 
 	/**
 	 * Gets the connected voice channels.

--- a/src/main/java/sx/blah/discord/api/internal/DiscordClientImpl.java
+++ b/src/main/java/sx/blah/discord/api/internal/DiscordClientImpl.java
@@ -6,14 +6,14 @@ import org.apache.http.message.BasicNameValuePair;
 import sx.blah.discord.Discord4J;
 import sx.blah.discord.api.IDiscordClient;
 import sx.blah.discord.api.events.EventDispatcher;
+import sx.blah.discord.api.internal.json.requests.*;
+import sx.blah.discord.api.internal.json.responses.*;
 import sx.blah.discord.handle.impl.events.DiscordDisconnectedEvent;
 import sx.blah.discord.handle.impl.events.PresenceUpdateEvent;
 import sx.blah.discord.handle.impl.events.ReadyEvent;
 import sx.blah.discord.handle.impl.events.StatusChangeEvent;
 import sx.blah.discord.handle.impl.obj.User;
 import sx.blah.discord.handle.obj.*;
-import sx.blah.discord.api.internal.json.requests.*;
-import sx.blah.discord.api.internal.json.responses.*;
 import sx.blah.discord.modules.ModuleLoader;
 import sx.blah.discord.util.DiscordException;
 import sx.blah.discord.util.Image;
@@ -23,11 +23,7 @@ import sx.blah.discord.util.RateLimitException;
 import java.io.UnsupportedEncodingException;
 import java.time.LocalDateTime;
 import java.util.*;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.CopyOnWriteArrayList;
-import java.util.concurrent.Executors;
-import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.TimeUnit;
+import java.util.concurrent.*;
 import java.util.stream.Collectors;
 
 /**
@@ -695,6 +691,21 @@ public final class DiscordClientImpl implements IDiscordClient {
 	@Override
 	public long getResponseTime(int shard) {
 		return this.getWebSocket(shard).getResponseTime();
+	}
+
+	@Override
+	public long getResponseTime() {
+		return getResponseTime(0);
+	}
+
+	@Override
+	public long getAverageResponseTime() {
+		long total = 0;
+		final int shardCount = getShardCount();
+		for (int i = 0; i < shardCount; i++)
+			total += getResponseTime(i);
+
+		return total / shardCount;
 	}
 
 	@Override


### PR DESCRIPTION
### Prerequisites
* [x] I have read and understood the [contribution guidelines](CONTRIBUTING.md)
* [x] This pull request follows the code style of the project
* [x] I have tested this feature thoroughly

### Changes Proposed in this Pull Request
* Add `getResponseTime` with no parameters (defaults to shard 0)
* Add `getAverageResponseTime`
* Also fixed a tiny spelling error in a doc


