### PR TITLE
Propagate status and presence changes throughout all shards

### DIFF
--- a/src/main/java/sx/blah/discord/api/internal/DiscordClientImpl.java
+++ b/src/main/java/sx/blah/discord/api/internal/DiscordClientImpl.java
@@ -358,7 +358,11 @@ public final class DiscordClientImpl implements IDiscordClient {
 			dispatcher.dispatch(new PresenceUpdateEvent(getOurUser(), oldPresence, newPresence));
 		}
 
-		getWebSocket(0).send(DiscordUtils.GSON.toJson(new PresenceUpdateRequest(isIdle ? System.currentTimeMillis() : null, status)));
+		final String request = DiscordUtils.GSON
+				.toJson(new PresenceUpdateRequest(isIdle ? System.currentTimeMillis() : null, status));
+		for (int i = 0; i < getShardCount(); i++) {
+			getWebSocket(i).send(request);
+		}
 	}
 
 	@Override


### PR DESCRIPTION
### Prerequisites
* [x] I have read and understood the [contribution guidelines](CONTRIBUTING.md)
* [x] This pull request follows the code style of the project
* [x] I have tested this feature thoroughly

### Changes Proposed in this Pull Request
* Status and presence changes were only being sent to shard 0
  * The fix is that it's now sent to all shards
  * Ideally, I'd like to be able to control each presence/status for each shard individually but it'd be a bigger overhaul


