### PR TITLE
Add status and presence changing per shard

### DIFF
--- a/src/main/java/sx/blah/discord/api/IDiscordClient.java
+++ b/src/main/java/sx/blah/discord/api/IDiscordClient.java
@@ -7,8 +7,8 @@ import sx.blah.discord.handle.impl.obj.*;
 import sx.blah.discord.handle.obj.*;
 import sx.blah.discord.modules.ModuleLoader;
 import sx.blah.discord.util.DiscordException;
-import sx.blah.discord.util.RateLimitException;
 import sx.blah.discord.util.Image;
+import sx.blah.discord.util.RateLimitException;
 
 import java.time.LocalDateTime;
 import java.util.Collection;
@@ -100,18 +100,38 @@ public interface IDiscordClient {
 	void changeAvatar(Image avatar) throws DiscordException, RateLimitException;
 
 	/**
-	 * Changes this user's presence.
+	 * Changes this user's presence across all shards.
 	 *
 	 * @param isIdle If true, this user becomes idle, or online if false.
 	 */
 	void changePresence(boolean isIdle);
 
 	/**
-	 * Changes the status of the bot user.
+	 * Changes the status of the bot user across all shards.
 	 *
 	 * @param status The new status to use.
 	 */
 	void changeStatus(Status status);
+
+	/**
+	 * Changes this user's presence.
+	 *
+	 * @param index  The shard number to set it on.
+	 * @param isIdle If true, this user becomes idle, or online if false.
+	 *
+	 * @throws IllegalArgumentException If an invalid index is provided.
+	 */
+	void changePresence(boolean isIdle, int index);
+
+	/**
+	 * Changes the status of the bot user.
+	 *
+	 * @param index  The shard number to set it on.
+	 * @param status The new status to use.
+	 *
+	 *               @throws IllegalArgumentException If an invalid index is provided.
+	 */
+	void changeStatus(Status status, int index);
 
 	/**
 	 * Checks if the api is ready to be interacted with (if it is logged in).

--- a/src/main/java/sx/blah/discord/api/internal/DiscordUtils.java
+++ b/src/main/java/sx/blah/discord/api/internal/DiscordUtils.java
@@ -264,11 +264,11 @@ public class DiscordUtils {
 					if (user != null) {
 						Status status = getStatusFromJSON(presence.game);
 						if (status.getType() == Status.StatusType.STREAM) {
-							user.setPresence(Presences.STREAMING);
+							user.setPresence(Presences.STREAMING, 0);
 						} else {
-							user.setPresence(Presences.valueOf((presence.status).toUpperCase()));
+							user.setPresence(Presences.valueOf((presence.status).toUpperCase()), 0);
 						}
-						user.setStatus(status);
+						user.setStatus(status, 0);
 					}
 				}
 

--- a/src/main/java/sx/blah/discord/api/internal/DiscordWS.java
+++ b/src/main/java/sx/blah/discord/api/internal/DiscordWS.java
@@ -841,14 +841,14 @@ public class DiscordWS {
 
 				if (!user.getPresence().equals(presence)) {
 					Presences oldPresence = user.getPresence();
-					user.setPresence(presence);
-					client.dispatcher.dispatch(new PresenceUpdateEvent(user, oldPresence, presence));
+					user.setPresence(presence, 0);
+					client.dispatcher.dispatch(new PresenceUpdateEvent(user, oldPresence, presence, 0));
 					Discord4J.LOGGER.debug(LogMarkers.EVENTS, "User \"{}\" changed presence to {}", user.getName(), user.getPresence());
 				}
 				if (!user.getStatus().equals(status)) {
 					Status oldStatus = user.getStatus();
-					user.setStatus(status);
-					client.dispatcher.dispatch(new StatusChangeEvent(user, oldStatus, status));
+					user.setStatus(status, 0);
+					client.dispatcher.dispatch(new StatusChangeEvent(user, oldStatus, status, 0));
 					Discord4J.LOGGER.debug(LogMarkers.EVENTS, "User \"{}\" changed status to {}.", user.getName(), status);
 				}
 			}

--- a/src/main/java/sx/blah/discord/handle/impl/events/PresenceUpdateEvent.java
+++ b/src/main/java/sx/blah/discord/handle/impl/events/PresenceUpdateEvent.java
@@ -11,11 +11,13 @@ public class PresenceUpdateEvent extends Event {
 
 	private final IUser user;
 	private final Presences oldPresence, newPresence;
+	private final int index;
 
-	public PresenceUpdateEvent(IUser user, Presences oldPresence, Presences newPresence) {
+	public PresenceUpdateEvent(IUser user, Presences oldPresence, Presences newPresence, int index) {
 		this.user = user;
 		this.oldPresence = oldPresence;
 		this.newPresence = newPresence;
+		this.index = index;
 	}
 
 	/**
@@ -43,5 +45,14 @@ public class PresenceUpdateEvent extends Event {
 	 */
 	public IUser getUser() {
 		return user;
+	}
+
+	/**
+	 * In the case of the client, the shard. Otherwise, the index.
+	 *
+	 * @return The index.
+	 */
+	public int getIndex() {
+		return index;
 	}
 }

--- a/src/main/java/sx/blah/discord/handle/impl/events/StatusChangeEvent.java
+++ b/src/main/java/sx/blah/discord/handle/impl/events/StatusChangeEvent.java
@@ -11,11 +11,13 @@ public class StatusChangeEvent extends Event {
 
 	private final IUser user;
 	private final Status oldStatus, newStatus;
+	private final int index;
 
-	public StatusChangeEvent(IUser user, Status oldStatus, Status newStatus) {
+	public StatusChangeEvent(IUser user, Status oldStatus, Status newStatus, int index) {
 		this.user = user;
 		this.oldStatus = oldStatus;
 		this.newStatus = newStatus;
+		this.index = index;
 	}
 
 	/**
@@ -43,5 +45,14 @@ public class StatusChangeEvent extends Event {
 	 */
 	public Status getOldStatus() {
 		return oldStatus;
+	}
+
+	/**
+	 * In the case of the client, the shard. Otherwise, the index.
+	 *
+	 * @return The index.
+	 */
+	public int getIndex() {
+		return index;
 	}
 }

--- a/src/main/java/sx/blah/discord/handle/obj/IUser.java
+++ b/src/main/java/sx/blah/discord/handle/obj/IUser.java
@@ -20,11 +20,20 @@ public interface IUser extends IDiscordObject<IUser> {
 	String getName();
 
 	/**
-	 * Gets the status for this user.
+	 * Gets the FIRST status for this user. This will only work with index=0 for non-client users (returns null otherwise).
 	 *
 	 * @return The user's status.
 	 */
 	Status getStatus();
+
+	/**
+	 * Gets the status for this user.
+	 *
+	 * @param index The status index.
+	 *
+	 * @return The user's status.
+	 */
+	Status getStatus(int index);
 
 	/**
 	 * Gets the user's avatar id.
@@ -41,11 +50,20 @@ public interface IUser extends IDiscordObject<IUser> {
 	String getAvatarURL();
 
 	/**
-	 * Gets the user's presence.
+	 * Gets the user's FIRST presence.
 	 *
 	 * @return The user's presence.
 	 */
 	Presences getPresence();
+
+	/**
+	 * Gets the user's presence by the shard number. This will only work with index=0 for non-client users (returns null otherwise).
+	 *
+	 * @param index The presence index.
+	 *
+	 * @return The user's presence.
+	 */
+	Presences getPresence(int index);
 
 	/**
 	 * Gets the name displayed to a guild for this user.
@@ -182,5 +200,19 @@ public interface IUser extends IDiscordObject<IUser> {
 	 * @throws MissingPermissionsException
 	 */
 	void removeRole(IRole role) throws MissingPermissionsException, RateLimitException, DiscordException;
+
+	/**
+	 * Gets the number of presences this user has. This only has a number greater than 1 for the client.
+	 *
+	 * @return The number of presences.
+	 */
+	int getNumberOfPresences();
+
+	/**
+	 * Gets the number of statuses this user has. This only has a number greater than 1 for the client.
+	 *
+	 * @return The number of statuses.
+	 */
+	int getNumberOfStatuses();
 
 }

--- a/src/main/java/sx/blah/discord/handle/obj/Presences.java
+++ b/src/main/java/sx/blah/discord/handle/obj/Presences.java
@@ -19,9 +19,5 @@ public enum Presences {
 	/**
 	 * Represents that the user is streaming.
 	 */
-	STREAMING,
-	/**
-	 * Represents that the user is in 'do not disturb' mode.
-	 */
-	DND
+	STREAMING
 }

--- a/src/main/java/sx/blah/discord/handle/obj/Presences.java
+++ b/src/main/java/sx/blah/discord/handle/obj/Presences.java
@@ -19,5 +19,9 @@ public enum Presences {
 	/**
 	 * Represents that the user is streaming.
 	 */
-	STREAMING
+	STREAMING,
+	/**
+	 * Represents that the user is in 'do not disturb' mode.
+	 */
+	DND
 }


### PR DESCRIPTION
### Prerequisites
* [x] I have read and understood the [contribution guidelines](CONTRIBUTING.md)
* [x] This pull request follows the code style of the project
* [x] I have tested this feature thoroughly

### Changes Proposed in this Pull Request
* As noted in #124, I wanted the ability to __set presences and statuses per shard__
  * That is the change in this PR
  * Users that aren't the client only have one presence and status, though (since we can't see their shards, obviously)

* Added `changePresence` and `changeStatus` with a shard number
  * Not passing a shard number defaults to all shards to allow backwards compatibility
* Added index parameters for `getStatus` and `getPresence`
  * Only works on index 0 for non-clients, but the parameter-less version of the getters defaults to 0
  * Passing a shard number outside of the range (less than zero or more than shard count) will result in an IllegalArgumentException being thrown for the `getX` and `changeX` methods

