### PR TITLE
Fixed ReadyEvent being called on reconnect

### DIFF
--- a/src/main/java/sx/blah/discord/api/internal/DiscordClientImpl.java
+++ b/src/main/java/sx/blah/discord/api/internal/DiscordClientImpl.java
@@ -413,7 +413,6 @@ public final class DiscordClientImpl implements IDiscordClient {
 	@Override
 	public boolean isReady(int shard) {
 		if (!this.ws.containsKey(shard) || !this.getWebSocket(shard).isConnected.get() || this.getWebSocket(shard).isReconnecting.get()) {
-			isReady = false;
 			return false;
 		}
 		return true;


### PR DESCRIPTION
### Prerequisites
* [X] I have read and understood the [contribution guidelines](CONTRIBUTING.md)
* [X] This pull request follows the code style of the project
* [x] I have tested this feature thoroughly

### Changes Proposed in this Pull Request
* Removed setting isReady to false if the websocket isn't ready
