### PR TITLE
Fixed volume changing for AudioInputStreamProvider when using AudioPlayer::queue(IAudioProvider)

### DIFF
--- a/src/main/java/sx/blah/discord/util/audio/AudioPlayer.java
+++ b/src/main/java/sx/blah/discord/util/audio/AudioPlayer.java
@@ -254,7 +254,7 @@ public class AudioPlayer implements IAudioProvider {
 			try {
 				track = new Track((AudioInputStreamProvider) provider);
 			} catch (IOException exception) {
-				Discord4J.LOGGER.error(LogMarkers.VOICE, "Discord4J Queue Exception", e);
+				Discord4J.LOGGER.error(LogMarkers.VOICE, "Discord4J Queue Exception", exception);
 				track = new Track(provider);
 			}
 		else

--- a/src/main/java/sx/blah/discord/util/audio/AudioPlayer.java
+++ b/src/main/java/sx/blah/discord/util/audio/AudioPlayer.java
@@ -248,7 +248,13 @@ public class AudioPlayer implements IAudioProvider {
 	 * @return The {@link Track} object representing this audio provider.
 	 */
 	public Track queue(IAudioProvider provider) {
-		Track track = new Track(provider);
+		Track track;
+
+		if (provider instanceof AudioInputStreamProvider)
+			track = new Track((AudioInputStreamProvider) provider);
+		else
+			track = new Track(provider);
+
 		queue(track);
 		return track;
 	}

--- a/src/main/java/sx/blah/discord/util/audio/AudioPlayer.java
+++ b/src/main/java/sx/blah/discord/util/audio/AudioPlayer.java
@@ -251,7 +251,12 @@ public class AudioPlayer implements IAudioProvider {
 		Track track;
 
 		if (provider instanceof AudioInputStreamProvider)
-			track = new Track((AudioInputStreamProvider) provider);
+			try {
+				track = new Track((AudioInputStreamProvider) provider);
+			} catch (IOException exception) {
+				Discord4J.LOGGER.error(LogMarkers.VOICE, "Discord4J Queue Exception", e);
+				track = new Track(provider);
+			}
 		else
 			track = new Track(provider);
 

--- a/src/main/java/sx/blah/discord/util/audio/AudioPlayer.java
+++ b/src/main/java/sx/blah/discord/util/audio/AudioPlayer.java
@@ -9,7 +9,18 @@ import sx.blah.discord.handle.audio.IAudioProcessor;
 import sx.blah.discord.handle.audio.IAudioProvider;
 import sx.blah.discord.handle.obj.IGuild;
 import sx.blah.discord.util.LogMarkers;
-import sx.blah.discord.util.audio.events.*;
+import sx.blah.discord.util.audio.events.AudioPlayerCleanEvent;
+import sx.blah.discord.util.audio.events.AudioPlayerInitEvent;
+import sx.blah.discord.util.audio.events.LoopStateChangeEvent;
+import sx.blah.discord.util.audio.events.PauseStateChangeEvent;
+import sx.blah.discord.util.audio.events.ProcessorAddEvent;
+import sx.blah.discord.util.audio.events.ProcessorRemoveEvent;
+import sx.blah.discord.util.audio.events.ShuffleEvent;
+import sx.blah.discord.util.audio.events.TrackFinishEvent;
+import sx.blah.discord.util.audio.events.TrackQueueEvent;
+import sx.blah.discord.util.audio.events.TrackSkipEvent;
+import sx.blah.discord.util.audio.events.TrackStartEvent;
+import sx.blah.discord.util.audio.events.VolumeChangeEvent;
 import sx.blah.discord.util.audio.processors.MultiProcessor;
 import sx.blah.discord.util.audio.processors.PauseableProcessor;
 import sx.blah.discord.util.audio.providers.AudioInputStreamProvider;
@@ -251,12 +262,7 @@ public class AudioPlayer implements IAudioProvider {
 		Track track;
 
 		if (provider instanceof AudioInputStreamProvider)
-			try {
-				track = new Track((AudioInputStreamProvider) provider);
-			} catch (IOException exception) {
-				Discord4J.LOGGER.error(LogMarkers.VOICE, "Discord4J Queue Exception", exception);
-				track = new Track(provider);
-			}
+			track = new Track((AudioInputStreamProvider) provider);
 		else
 			track = new Track(provider);
 
@@ -476,11 +482,11 @@ public class AudioPlayer implements IAudioProvider {
 			stream = null;
 		}
 
-		public Track(AudioInputStreamProvider provider) throws IOException {
+		public Track(AudioInputStreamProvider provider) {
 			this(provider.getStream());
 		}
 
-		public Track(AudioInputStream stream) throws IOException {
+		public Track(AudioInputStream stream) {
 			this.stream = new AmplitudeAudioInputStream(DiscordUtils.getPCMStream(stream));
 			this.provider = new AudioInputStreamProvider(this.stream);
 


### PR DESCRIPTION
### Prerequisites
* [x] I have read and understood the [contribution guidelines](CONTRIBUTING.md)
* [x] This pull request follows the code style of the project
* [x] I have tested this feature thoroughly
  * [Proof of testing](http://imgur.com/a/qM1ty)

**Issues Fixed:** None available about the bug.

### Changes Proposed in this Pull Request
* Changing `AudioPlayer::queue(IAudioProvider)`, by simply redirecting the **IAudioProvider** parameter to it's correct constructor within **Track**

...

`AudioPlayer::queue(IAudioProvider)` now calls the correct constructor of **Track** for instances of **AudioInputStreamProvider**. This solves a bug where the volume was not being changed when using this method with an AudioInputStreamProvider instance being passed as parameter.