### PR TITLE
Handle unknown enum constants cleanly

### DIFF
--- a/src/main/java/sx/blah/discord/api/internal/DiscordUtils.java
+++ b/src/main/java/sx/blah/discord/api/internal/DiscordUtils.java
@@ -232,7 +232,7 @@ public class DiscordUtils {
 						if (status.getType() == Status.StatusType.STREAM) {
 							user.setPresence(Presences.STREAMING);
 						} else {
-							user.setPresence(Presences.valueOf((presence.status).toUpperCase()));
+							user.setPresence(Presences.get(presence.status));
 						}
 						user.setStatus(status);
 					}

--- a/src/main/java/sx/blah/discord/api/internal/DiscordVoiceWS.java
+++ b/src/main/java/sx/blah/discord/api/internal/DiscordVoiceWS.java
@@ -83,7 +83,7 @@ public class DiscordVoiceWS extends WebSocketAdapter {
 	@Override
 	public void onWebSocketText(String message) {
 		JsonObject payload = DiscordUtils.GSON.fromJson(message, JsonObject.class);
-		VoiceOps op = VoiceOps.values()[payload.get("op").getAsInt()];
+		VoiceOps op = VoiceOps.get(payload.get("op").getAsInt());
 		JsonElement d = payload.has("d") && !(payload.get("d") instanceof JsonNull) ? payload.get("d") : null;
 
 		switch (op) {
@@ -114,6 +114,9 @@ public class DiscordVoiceWS extends WebSocketAdapter {
 				VoiceSpeakingResponse speaking = DiscordUtils.GSON.fromJson(payload.get("d"), VoiceSpeakingResponse.class);
 				IUser user = client.getUserByID(speaking.user_id);
 				client.dispatcher.dispatch(new VoiceUserSpeakingEvent(user, speaking.ssrc, speaking.isSpeaking));
+				break;
+			case UNKNOWN:
+				Discord4J.LOGGER.debug(LogMarkers.VOICE_WEBSOCKET, "Received unknown voice opcode, {}", message);
 				break;
 		}
 	}

--- a/src/main/java/sx/blah/discord/api/internal/DiscordWS.java
+++ b/src/main/java/sx/blah/discord/api/internal/DiscordWS.java
@@ -72,7 +72,7 @@ public class DiscordWS extends WebSocketAdapter {
 	@Override
 	public void onWebSocketText(String message) {
 		JsonObject payload = DiscordUtils.GSON.fromJson(message, JsonObject.class);
-		GatewayOps op = GatewayOps.values()[payload.get("op").getAsInt()];
+		GatewayOps op = GatewayOps.get(payload.get("op").getAsInt());
 		JsonElement d = payload.has("d") && !payload.get("d").isJsonNull() ? payload.get("d") : null;
 
 		if (payload.has("s") && !payload.get("s").isJsonNull()) seq = payload.get("s").getAsLong();
@@ -95,9 +95,9 @@ public class DiscordWS extends WebSocketAdapter {
 			case INVALID_SESSION: disconnect(DiscordDisconnectedEvent.Reason.INVALID_SESSION_OP); break;
 			case HEARTBEAT: send(GatewayOps.HEARTBEAT, seq);
 			case HEARTBEAT_ACK: /* TODO: Handle missed pings */ break;
-
-			default:
-				Discord4J.LOGGER.warn(LogMarkers.WEBSOCKET, "Unhandled opcode received: {} (ignoring), REPORT THIS TO THE DISCORD4J DEV!", op);
+			case UNKNOWN:
+				Discord4J.LOGGER.debug(LogMarkers.WEBSOCKET, "Received unknown opcode, {}", message);
+				break;
 		}
 	}
 

--- a/src/main/java/sx/blah/discord/api/internal/DispatchHandler.java
+++ b/src/main/java/sx/blah/discord/api/internal/DispatchHandler.java
@@ -320,7 +320,7 @@ public class DispatchHandler {
 	private void presenceUpdate(PresenceUpdateEventResponse event) {
 		Status status = DiscordUtils.getStatusFromJSON(event.game);
 		Presences presence = status.getType() == Status.StatusType.STREAM ?
-				Presences.STREAMING : Presences.valueOf(event.status.toUpperCase());
+				Presences.STREAMING : Presences.get(event.status);
 		Guild guild = (Guild) client.getGuildByID(event.guild_id);
 		if (guild != null) {
 			User user = (User) guild.getUserByID(event.user.id);

--- a/src/main/java/sx/blah/discord/api/internal/GatewayOps.java
+++ b/src/main/java/sx/blah/discord/api/internal/GatewayOps.java
@@ -51,5 +51,17 @@ public enum GatewayOps {
 	/**
 	 * Sent after a heartbeat was received.
 	 */
-	HEARTBEAT_ACK
+	HEARTBEAT_ACK,
+	/**
+	 * Unknown opcode.
+	 */
+	UNKNOWN;
+
+	public static GatewayOps get(int opcode) {
+		if (opcode >= values().length) {
+			return UNKNOWN;
+		} else {
+			return values()[opcode];
+		}
+	}
 }

--- a/src/main/java/sx/blah/discord/api/internal/VoiceOps.java
+++ b/src/main/java/sx/blah/discord/api/internal/VoiceOps.java
@@ -30,5 +30,18 @@ public enum VoiceOps {
 	/**
 	 * Used to indicate which users are speaking
 	 */
-	SPEAKING
+	SPEAKING,
+
+	/**
+	 * Unknown opcode.
+	 */
+	UNKNOWN;
+
+	public static VoiceOps get(int opcode) {
+		if (opcode >= values().length) {
+			return UNKNOWN;
+		} else {
+			return values()[opcode];
+		}
+	}
 }

--- a/src/main/java/sx/blah/discord/handle/impl/obj/Guild.java
+++ b/src/main/java/sx/blah/discord/handle/impl/obj/Guild.java
@@ -136,7 +136,7 @@ public class Guild implements IGuild {
 		this.afkChannel = afkChannel;
 		this.afkTimeout = afkTimeout;
 		this.regionID = region;
-		this.verification = VerificationLevel.values()[verification];
+		this.verification = VerificationLevel.get(verification);
 		this.audioManager = new AudioManager(this);
 		this.emojis = new CopyOnWriteArrayList<>();
 	}
@@ -589,7 +589,7 @@ public class Guild implements IGuild {
 	 * @param verification The verification level.
 	 */
 	public void setVerificationLevel(int verification) {
-		this.verification = VerificationLevel.values()[verification];
+		this.verification = VerificationLevel.get(verification);
 	}
 
 	@Override

--- a/src/main/java/sx/blah/discord/handle/obj/Presences.java
+++ b/src/main/java/sx/blah/discord/handle/obj/Presences.java
@@ -23,5 +23,17 @@ public enum Presences {
 	/**
 	 * Represents that the user is in 'do not disturb' mode.
 	 */
-	DND
+	DND,
+	/**
+	 * Unknown presence.
+	 */
+	UNKNOWN;
+
+	public static Presences get(String name) {
+		try {
+			return valueOf(name.toUpperCase());
+		} catch (IllegalArgumentException e) {
+			return UNKNOWN;
+		}
+	}
 }

--- a/src/main/java/sx/blah/discord/handle/obj/VerificationLevel.java
+++ b/src/main/java/sx/blah/discord/handle/obj/VerificationLevel.java
@@ -19,5 +19,17 @@ public enum VerificationLevel {
 	/**
 	 * Represents a verification level of (╯°□°）╯︵ ┻━┻
 	 */
-	HIGH
+	HIGH,
+	/**
+	 * Unknown verification level
+	 */
+	UNKNOWN;
+
+	public static VerificationLevel get(int id) {
+		if (id >= values().length) {
+			return UNKNOWN;
+		} else {
+			return values()[id];
+		}
+	}
 }


### PR DESCRIPTION
### Prerequisites
* [x] I have read and understood the [contribution guidelines](CONTRIBUTING.md)
* [x] This pull request follows the code style of the project
* [x] I have tested this feature thoroughly
  * [Proof of testing](https://u.pomf.is/jrqlia.png)

**Issues Fixed:** Opcodes, presences and verification levels that were not supported would cause an error.

### Changes Proposed in this Pull Request
* A get method in the opcode enums to safely get an opcode or return UNKNOWN if it can't.
* Same as above, for the Presences and VerificationLevel enums.