### PR TITLE
AudioPlayer::queue now calls the correct Track constructor for AudioInputStreamProvider instances

### DIFF
--- a/src/main/java/sx/blah/discord/util/audio/AudioPlayer.java
+++ b/src/main/java/sx/blah/discord/util/audio/AudioPlayer.java
@@ -248,7 +248,13 @@ public class AudioPlayer implements IAudioProvider {
 	 * @return The {@link Track} object representing this audio provider.
 	 */
 	public Track queue(IAudioProvider provider) {
-		Track track = new Track(provider);
+		Track track;
+
+		if (provider instanceof AudioInputStreamProvider)
+			track = new Track((AudioInputStreamProvider) provider);
+		else
+			track = new Track(provider);
+
 		queue(track);
 		return track;
 	}
@@ -465,11 +471,11 @@ public class AudioPlayer implements IAudioProvider {
 			stream = null;
 		}
 
-		public Track(AudioInputStreamProvider provider) throws IOException {
+		public Track(AudioInputStreamProvider provider) {
 			this(provider.getStream());
 		}
 
-		public Track(AudioInputStream stream) throws IOException {
+		public Track(AudioInputStream stream) {
 			this.stream = new AmplitudeAudioInputStream(DiscordUtils.getPCMStream(stream));
 			this.provider = new AudioInputStreamProvider(this.stream);
 


### PR DESCRIPTION
### Prerequisites
* [x] I have read and understood the [contribution guidelines](CONTRIBUTING.md)
* [x] This pull request follows the code style of the project
* [x] I have tested this feature thoroughly
  * [Proof of testing](http://imgur.com/gallery/jRUzI)

**Issues Fixed:** None available about this bug.

### Changes Proposed in this Pull Request
* `Track(AudioInputStream)` and `Track(AudioInputStreamProvider)` constructors no longer declare `IOException` as being throwable (since, actually, it's never thrown)
* `AudioPlayer::queue(IAudioProvider)` now calls the correct `Track` constructor for `AudioInputStreamProvider` instances passed as parameter