### PR TITLE
Add isDeleted() to IMessage (re made after failing to use git)

### DIFF
--- a/src/main/java/sx/blah/discord/api/internal/DispatchHandler.java
+++ b/src/main/java/sx/blah/discord/api/internal/DispatchHandler.java
@@ -36,99 +36,38 @@ public class DispatchHandler {
 	public void handle(JsonObject event) {
 		String type = event.get("t").getAsString();
 		switch (type) {
-			case "RESUMED":
-				Discord4J.LOGGER.debug(LogMarkers.WEBSOCKET, "Session resumed on shard " + shard.getInfo()[0]);
-				break;
-			case "READY":
-				ready(DiscordUtils.GSON.fromJson(event.get("d"), ReadyResponse.class));
-				break;
-			case "MESSAGE_CREATE":
-				messageCreate(DiscordUtils.GSON.fromJson(event.get("d"), MessageObject.class));
-				break;
-			case "TYPING_START":
-				typingStart(DiscordUtils.GSON.fromJson(event.get("d"), TypingEventResponse.class));
-				break;
-			case "GUILD_CREATE":
-				guildCreate(DiscordUtils.GSON.fromJson(event.get("d"), GuildObject.class));
-				break;
-			case "GUILD_MEMBER_ADD":
-				guildMemberAdd(DiscordUtils.GSON.fromJson(event.get("d"), GuildMemberAddEventResponse.class));
-				break;
-			case "GUILD_MEMBER_REMOVE":
-				guildMemberRemove(DiscordUtils.GSON.fromJson(event.get("d"), GuildMemberRemoveEventResponse.class));
-				break;
-			case "GUILD_MEMBER_UPDATE":
-				guildMemberUpdate(DiscordUtils.GSON.fromJson(event.get("d"), GuildMemberUpdateEventResponse.class));
-				break;
-			case "MESSAGE_UPDATE":
-				messageUpdate(DiscordUtils.GSON.fromJson(event.get("d"), MessageObject.class));
-				break;
-			case "MESSAGE_DELETE":
-				messageDelete(DiscordUtils.GSON.fromJson(event.get("d"), MessageDeleteEventResponse.class));
-				break;
-			case "MESSAGE_DELETE_BULK":
-				messageDeleteBulk(DiscordUtils.GSON.fromJson(event.get("d"), MessageDeleteBulkEventResponse.class));
-				break;
-			case "PRESENCE_UPDATE":
-				presenceUpdate(DiscordUtils.GSON.fromJson(event.get("d"), PresenceUpdateEventResponse.class));
-				break;
-			case "GUILD_DELETE":
-				guildDelete(DiscordUtils.GSON.fromJson(event.get("d"), GuildObject.class));
-				break;
-			case "CHANNEL_CREATE":
-				channelCreate(event.get("d").getAsJsonObject());
-				break;
-			case "CHANNEL_DELETE":
-				channelDelete(DiscordUtils.GSON.fromJson(event.get("d"), ChannelObject.class));
-				break;
-			case "CHANNEL_PINS_UPDATE": /* Implemented in MESSAGE_UPDATE. Ignored */
-				break;
-			case "USER_UPDATE":
-				userUpdate(DiscordUtils.GSON.fromJson(event.get("d"), UserUpdateEventResponse.class));
-				break;
-			case "CHANNEL_UPDATE":
-				channelUpdate(DiscordUtils.GSON.fromJson(event.get("d"), ChannelObject.class));
-				break;
-			case "GUILD_MEMBERS_CHUNK":
-				guildMembersChunk(DiscordUtils.GSON.fromJson(event.get("d"), GuildMemberChunkEventResponse.class));
-				break;
-			case "GUILD_UPDATE":
-				guildUpdate(DiscordUtils.GSON.fromJson(event.get("d"), GuildObject.class));
-				break;
-			case "GUILD_ROLE_CREATE":
-				guildRoleCreate(DiscordUtils.GSON.fromJson(event.get("d"), GuildRoleEventResponse.class));
-				break;
-			case "GUILD_ROLE_UPDATE":
-				guildRoleUpdate(DiscordUtils.GSON.fromJson(event.get("d"), GuildRoleEventResponse.class));
-				break;
-			case "GUILD_ROLE_DELETE":
-				guildRoleDelete(DiscordUtils.GSON.fromJson(event.get("d"), GuildRoleDeleteEventResponse.class));
-				break;
-			case "GUILD_BAN_ADD":
-				guildBanAdd(DiscordUtils.GSON.fromJson(event.get("d"), GuildBanEventResponse.class));
-				break;
-			case "GUILD_BAN_REMOVE":
-				guildBanRemove(DiscordUtils.GSON.fromJson(event.get("d"), GuildBanEventResponse.class));
-				break;
-			case "GUILD_EMOJIS_UPDATE":
-				guildEmojisUpdate(DiscordUtils.GSON.fromJson(event.get("d"), GuildEmojiUpdateResponse.class));
-				break;
-			case "GUILD_INTEGRATIONS_UPDATE": /* TODO: Impl Guild integrations */
-				break;
-			case "VOICE_STATE_UPDATE":
-				voiceStateUpdate(DiscordUtils.GSON.fromJson(event.get("d"), VoiceStateObject.class));
-				break;
-			case "VOICE_SERVER_UPDATE":
-				voiceServerUpdate(DiscordUtils.GSON.fromJson(event.get("d"), VoiceUpdateResponse.class));
-				break;
-			case "MESSAGE_REACTION_ADD":
-				reactionAdd(DiscordUtils.GSON.fromJson(event.get("d"), ReactionEventResponse.class));
-				break;
-			case "MESSAGE_REACTION_REMOVE":
-				reactionRemove(DiscordUtils.GSON.fromJson(event.get("d"), ReactionEventResponse.class));
-				break;
-			case "MESSAGE_REACTION_REMOVE_ALL": /* REMOVE_ALL is 204 empty but REACTION_REMOVE is sent anyway */
-				break;
+			case "RESUMED": Discord4J.LOGGER.debug(LogMarkers.WEBSOCKET, "Session resumed on shard " + shard.getInfo()[0]); break;
+			case "READY": ready(DiscordUtils.GSON.fromJson(event.get("d"), ReadyResponse.class)); break;
+			case "MESSAGE_CREATE": messageCreate(DiscordUtils.GSON.fromJson(event.get("d"), MessageObject.class)); break;
+			case "TYPING_START": typingStart(DiscordUtils.GSON.fromJson(event.get("d"), TypingEventResponse.class)); break;
+			case "GUILD_CREATE": guildCreate(DiscordUtils.GSON.fromJson(event.get("d"), GuildObject.class)); break;
+			case "GUILD_MEMBER_ADD": guildMemberAdd(DiscordUtils.GSON.fromJson(event.get("d"), GuildMemberAddEventResponse.class)); break;
+			case "GUILD_MEMBER_REMOVE": guildMemberRemove(DiscordUtils.GSON.fromJson(event.get("d"), GuildMemberRemoveEventResponse.class)); break;
+			case "GUILD_MEMBER_UPDATE": guildMemberUpdate(DiscordUtils.GSON.fromJson(event.get("d"), GuildMemberUpdateEventResponse.class)); break;
+			case "MESSAGE_UPDATE": messageUpdate(DiscordUtils.GSON.fromJson(event.get("d"), MessageObject.class));break;
+			case "MESSAGE_DELETE": messageDelete(DiscordUtils.GSON.fromJson(event.get("d"), MessageDeleteEventResponse.class)); break;
+			case "MESSAGE_DELETE_BULK": messageDeleteBulk(DiscordUtils.GSON.fromJson(event.get("d"), MessageDeleteBulkEventResponse.class)); break;
+			case "PRESENCE_UPDATE": presenceUpdate(DiscordUtils.GSON.fromJson(event.get("d"), PresenceUpdateEventResponse.class)); break;
+			case "GUILD_DELETE": guildDelete(DiscordUtils.GSON.fromJson(event.get("d"), GuildObject.class)); break;
+			case "CHANNEL_CREATE": channelCreate(event.get("d").getAsJsonObject()); break;
+			case "CHANNEL_DELETE": channelDelete(DiscordUtils.GSON.fromJson(event.get("d"), ChannelObject.class)); break;
+			case "CHANNEL_PINS_UPDATE": /* Implemented in MESSAGE_UPDATE. Ignored */ break;
+			case "USER_UPDATE": userUpdate(DiscordUtils.GSON.fromJson(event.get("d"), UserUpdateEventResponse.class)); break;
+			case "CHANNEL_UPDATE": channelUpdate(DiscordUtils.GSON.fromJson(event.get("d"), ChannelObject.class)); break;
+			case "GUILD_MEMBERS_CHUNK": guildMembersChunk(DiscordUtils.GSON.fromJson(event.get("d"), GuildMemberChunkEventResponse.class)); break;
+			case "GUILD_UPDATE": guildUpdate(DiscordUtils.GSON.fromJson(event.get("d"), GuildObject.class)); break;
+			case "GUILD_ROLE_CREATE": guildRoleCreate(DiscordUtils.GSON.fromJson(event.get("d"), GuildRoleEventResponse.class)); break;
+			case "GUILD_ROLE_UPDATE": guildRoleUpdate(DiscordUtils.GSON.fromJson(event.get("d"), GuildRoleEventResponse.class)); break;
+			case "GUILD_ROLE_DELETE": guildRoleDelete(DiscordUtils.GSON.fromJson(event.get("d"), GuildRoleDeleteEventResponse.class)); break;
+			case "GUILD_BAN_ADD": guildBanAdd(DiscordUtils.GSON.fromJson(event.get("d"), GuildBanEventResponse.class)); break;
+			case "GUILD_BAN_REMOVE": guildBanRemove(DiscordUtils.GSON.fromJson(event.get("d"), GuildBanEventResponse.class)); break;
+			case "GUILD_EMOJIS_UPDATE": guildEmojisUpdate(DiscordUtils.GSON.fromJson(event.get("d"), GuildEmojiUpdateResponse.class)); break;
+			case "GUILD_INTEGRATIONS_UPDATE": /* TODO: Impl Guild integrations */ break;
+			case "VOICE_STATE_UPDATE": voiceStateUpdate(DiscordUtils.GSON.fromJson(event.get("d"), VoiceStateObject.class)); break;
+			case "VOICE_SERVER_UPDATE": voiceServerUpdate(DiscordUtils.GSON.fromJson(event.get("d"), VoiceUpdateResponse.class)); break;
+			case "MESSAGE_REACTION_ADD": reactionAdd(DiscordUtils.GSON.fromJson(event.get("d"), ReactionEventResponse.class)); break;
+			case "MESSAGE_REACTION_REMOVE": reactionRemove(DiscordUtils.GSON.fromJson(event.get("d"), ReactionEventResponse.class));break;
+			case "MESSAGE_REACTION_REMOVE_ALL": /* REMOVE_ALL is 204 empty but REACTION_REMOVE is sent anyway */ break;
 
 			default:
 				Discord4J.LOGGER.warn(LogMarkers.WEBSOCKET, "Unknown message received: {}, REPORT THIS TO THE DISCORD4J DEV!", type);

--- a/src/main/java/sx/blah/discord/api/internal/DispatchHandler.java
+++ b/src/main/java/sx/blah/discord/api/internal/DispatchHandler.java
@@ -301,13 +301,13 @@ public class DispatchHandler {
 		Channel channel = (Channel) client.getChannelByID(channelID);
 
 		if (channel != null) {
-			IMessage message = channel.getMessageByID(id);
+			Message message = (Message) channel.getMessageByID(id);
 			if (message != null) {
 				if (message.isPinned()) {
-					((Message) message).setPinned(false); //For consistency with the event
+					message.setPinned(false); //For consistency with the event
 					client.dispatcher.dispatch(new MessageUnpinEvent(message));
 				}
-
+				message.setDeleted(true);
 				client.dispatcher.dispatch(new MessageDeleteEvent(message));
 			}
 		}

--- a/src/main/java/sx/blah/discord/api/internal/DispatchHandler.java
+++ b/src/main/java/sx/blah/discord/api/internal/DispatchHandler.java
@@ -36,38 +36,99 @@ public class DispatchHandler {
 	public void handle(JsonObject event) {
 		String type = event.get("t").getAsString();
 		switch (type) {
-			case "RESUMED": Discord4J.LOGGER.debug(LogMarkers.WEBSOCKET, "Session resumed on shard " + shard.getInfo()[0]); break;
-			case "READY": ready(DiscordUtils.GSON.fromJson(event.get("d"), ReadyResponse.class)); break;
-			case "MESSAGE_CREATE": messageCreate(DiscordUtils.GSON.fromJson(event.get("d"), MessageObject.class)); break;
-			case "TYPING_START": typingStart(DiscordUtils.GSON.fromJson(event.get("d"), TypingEventResponse.class)); break;
-			case "GUILD_CREATE": guildCreate(DiscordUtils.GSON.fromJson(event.get("d"), GuildObject.class)); break;
-			case "GUILD_MEMBER_ADD": guildMemberAdd(DiscordUtils.GSON.fromJson(event.get("d"), GuildMemberAddEventResponse.class)); break;
-			case "GUILD_MEMBER_REMOVE": guildMemberRemove(DiscordUtils.GSON.fromJson(event.get("d"), GuildMemberRemoveEventResponse.class)); break;
-			case "GUILD_MEMBER_UPDATE": guildMemberUpdate(DiscordUtils.GSON.fromJson(event.get("d"), GuildMemberUpdateEventResponse.class)); break;
-			case "MESSAGE_UPDATE": messageUpdate(DiscordUtils.GSON.fromJson(event.get("d"), MessageObject.class)); break;
-			case "MESSAGE_DELETE": messageDelete(DiscordUtils.GSON.fromJson(event.get("d"), MessageDeleteEventResponse.class)); break;
-			case "MESSAGE_DELETE_BULK": messageDeleteBulk(DiscordUtils.GSON.fromJson(event.get("d"), MessageDeleteBulkEventResponse.class)); break;
-			case "PRESENCE_UPDATE": presenceUpdate(DiscordUtils.GSON.fromJson(event.get("d"), PresenceUpdateEventResponse.class)); break;
-			case "GUILD_DELETE": guildDelete(DiscordUtils.GSON.fromJson(event.get("d"), GuildObject.class)); break;
-			case "CHANNEL_CREATE": channelCreate(event.get("d").getAsJsonObject()); break;
-			case "CHANNEL_DELETE": channelDelete(DiscordUtils.GSON.fromJson(event.get("d"), ChannelObject.class)); break;
-			case "CHANNEL_PINS_UPDATE": /* Implemented in MESSAGE_UPDATE. Ignored */ break;
-			case "USER_UPDATE": userUpdate(DiscordUtils.GSON.fromJson(event.get("d"), UserUpdateEventResponse.class)); break;
-			case "CHANNEL_UPDATE": channelUpdate(DiscordUtils.GSON.fromJson(event.get("d"), ChannelObject.class)); break;
-			case "GUILD_MEMBERS_CHUNK": guildMembersChunk(DiscordUtils.GSON.fromJson(event.get("d"), GuildMemberChunkEventResponse.class)); break;
-			case "GUILD_UPDATE": guildUpdate(DiscordUtils.GSON.fromJson(event.get("d"), GuildObject.class)); break;
-			case "GUILD_ROLE_CREATE": guildRoleCreate(DiscordUtils.GSON.fromJson(event.get("d"), GuildRoleEventResponse.class)); break;
-			case "GUILD_ROLE_UPDATE": guildRoleUpdate(DiscordUtils.GSON.fromJson(event.get("d"), GuildRoleEventResponse.class)); break;
-			case "GUILD_ROLE_DELETE": guildRoleDelete(DiscordUtils.GSON.fromJson(event.get("d"), GuildRoleDeleteEventResponse.class)); break;
-			case "GUILD_BAN_ADD": guildBanAdd(DiscordUtils.GSON.fromJson(event.get("d"), GuildBanEventResponse.class)); break;
-			case "GUILD_BAN_REMOVE": guildBanRemove(DiscordUtils.GSON.fromJson(event.get("d"), GuildBanEventResponse.class)); break;
-			case "GUILD_EMOJIS_UPDATE": guildEmojisUpdate(DiscordUtils.GSON.fromJson(event.get("d"), GuildEmojiUpdateResponse.class)); break;
-			case "GUILD_INTEGRATIONS_UPDATE": /* TODO: Impl Guild integrations */ break;
-			case "VOICE_STATE_UPDATE": voiceStateUpdate(DiscordUtils.GSON.fromJson(event.get("d"), VoiceStateObject.class)); break;
-			case "VOICE_SERVER_UPDATE": voiceServerUpdate(DiscordUtils.GSON.fromJson(event.get("d"), VoiceUpdateResponse.class)); break;
-			case "MESSAGE_REACTION_ADD": reactionAdd(DiscordUtils.GSON.fromJson(event.get("d"), ReactionEventResponse.class)); break;
-			case "MESSAGE_REACTION_REMOVE": reactionRemove(DiscordUtils.GSON.fromJson(event.get("d"), ReactionEventResponse.class)); break;
-			case "MESSAGE_REACTION_REMOVE_ALL": /* REMOVE_ALL is 204 empty but REACTION_REMOVE is sent anyway */ break;
+			case "RESUMED":
+				Discord4J.LOGGER.debug(LogMarkers.WEBSOCKET, "Session resumed on shard " + shard.getInfo()[0]);
+				break;
+			case "READY":
+				ready(DiscordUtils.GSON.fromJson(event.get("d"), ReadyResponse.class));
+				break;
+			case "MESSAGE_CREATE":
+				messageCreate(DiscordUtils.GSON.fromJson(event.get("d"), MessageObject.class));
+				break;
+			case "TYPING_START":
+				typingStart(DiscordUtils.GSON.fromJson(event.get("d"), TypingEventResponse.class));
+				break;
+			case "GUILD_CREATE":
+				guildCreate(DiscordUtils.GSON.fromJson(event.get("d"), GuildObject.class));
+				break;
+			case "GUILD_MEMBER_ADD":
+				guildMemberAdd(DiscordUtils.GSON.fromJson(event.get("d"), GuildMemberAddEventResponse.class));
+				break;
+			case "GUILD_MEMBER_REMOVE":
+				guildMemberRemove(DiscordUtils.GSON.fromJson(event.get("d"), GuildMemberRemoveEventResponse.class));
+				break;
+			case "GUILD_MEMBER_UPDATE":
+				guildMemberUpdate(DiscordUtils.GSON.fromJson(event.get("d"), GuildMemberUpdateEventResponse.class));
+				break;
+			case "MESSAGE_UPDATE":
+				messageUpdate(DiscordUtils.GSON.fromJson(event.get("d"), MessageObject.class));
+				break;
+			case "MESSAGE_DELETE":
+				messageDelete(DiscordUtils.GSON.fromJson(event.get("d"), MessageDeleteEventResponse.class));
+				break;
+			case "MESSAGE_DELETE_BULK":
+				messageDeleteBulk(DiscordUtils.GSON.fromJson(event.get("d"), MessageDeleteBulkEventResponse.class));
+				break;
+			case "PRESENCE_UPDATE":
+				presenceUpdate(DiscordUtils.GSON.fromJson(event.get("d"), PresenceUpdateEventResponse.class));
+				break;
+			case "GUILD_DELETE":
+				guildDelete(DiscordUtils.GSON.fromJson(event.get("d"), GuildObject.class));
+				break;
+			case "CHANNEL_CREATE":
+				channelCreate(event.get("d").getAsJsonObject());
+				break;
+			case "CHANNEL_DELETE":
+				channelDelete(DiscordUtils.GSON.fromJson(event.get("d"), ChannelObject.class));
+				break;
+			case "CHANNEL_PINS_UPDATE": /* Implemented in MESSAGE_UPDATE. Ignored */
+				break;
+			case "USER_UPDATE":
+				userUpdate(DiscordUtils.GSON.fromJson(event.get("d"), UserUpdateEventResponse.class));
+				break;
+			case "CHANNEL_UPDATE":
+				channelUpdate(DiscordUtils.GSON.fromJson(event.get("d"), ChannelObject.class));
+				break;
+			case "GUILD_MEMBERS_CHUNK":
+				guildMembersChunk(DiscordUtils.GSON.fromJson(event.get("d"), GuildMemberChunkEventResponse.class));
+				break;
+			case "GUILD_UPDATE":
+				guildUpdate(DiscordUtils.GSON.fromJson(event.get("d"), GuildObject.class));
+				break;
+			case "GUILD_ROLE_CREATE":
+				guildRoleCreate(DiscordUtils.GSON.fromJson(event.get("d"), GuildRoleEventResponse.class));
+				break;
+			case "GUILD_ROLE_UPDATE":
+				guildRoleUpdate(DiscordUtils.GSON.fromJson(event.get("d"), GuildRoleEventResponse.class));
+				break;
+			case "GUILD_ROLE_DELETE":
+				guildRoleDelete(DiscordUtils.GSON.fromJson(event.get("d"), GuildRoleDeleteEventResponse.class));
+				break;
+			case "GUILD_BAN_ADD":
+				guildBanAdd(DiscordUtils.GSON.fromJson(event.get("d"), GuildBanEventResponse.class));
+				break;
+			case "GUILD_BAN_REMOVE":
+				guildBanRemove(DiscordUtils.GSON.fromJson(event.get("d"), GuildBanEventResponse.class));
+				break;
+			case "GUILD_EMOJIS_UPDATE":
+				guildEmojisUpdate(DiscordUtils.GSON.fromJson(event.get("d"), GuildEmojiUpdateResponse.class));
+				break;
+			case "GUILD_INTEGRATIONS_UPDATE": /* TODO: Impl Guild integrations */
+				break;
+			case "VOICE_STATE_UPDATE":
+				voiceStateUpdate(DiscordUtils.GSON.fromJson(event.get("d"), VoiceStateObject.class));
+				break;
+			case "VOICE_SERVER_UPDATE":
+				voiceServerUpdate(DiscordUtils.GSON.fromJson(event.get("d"), VoiceUpdateResponse.class));
+				break;
+			case "MESSAGE_REACTION_ADD":
+				reactionAdd(DiscordUtils.GSON.fromJson(event.get("d"), ReactionEventResponse.class));
+				break;
+			case "MESSAGE_REACTION_REMOVE":
+				reactionRemove(DiscordUtils.GSON.fromJson(event.get("d"), ReactionEventResponse.class));
+				break;
+			case "MESSAGE_REACTION_REMOVE_ALL": /* REMOVE_ALL is 204 empty but REACTION_REMOVE is sent anyway */
+				break;
 
 			default:
 				Discord4J.LOGGER.warn(LogMarkers.WEBSOCKET, "Unknown message received: {}, REPORT THIS TO THE DISCORD4J DEV!", type);
@@ -351,6 +412,7 @@ public class DispatchHandler {
 
 	private void guildDelete(GuildObject json) {
 		Guild guild = (Guild) client.getGuildByID(json.id);
+		guild.setDeleted(true);
 		client.getGuilds().remove(guild);
 		if (json.unavailable) { //Guild can't be reached
 			Discord4J.LOGGER.warn(LogMarkers.WEBSOCKET, "Guild with id {} is unavailable, is there an outage?", json.id);
@@ -404,7 +466,7 @@ public class DispatchHandler {
 					channel.getGuild().getChannels().remove(channel);
 				else
 					shard.privateChannels.remove(channel);
-
+				channel.setDeleted(true);
 				client.dispatcher.dispatch(new ChannelDeleteEvent(channel));
 			}
 		} else if (json.type.equalsIgnoreCase("voice")) {
@@ -504,6 +566,7 @@ public class DispatchHandler {
 			IRole role = guild.getRoleByID(event.role_id);
 			if (role != null) {
 				guild.getRoles().remove(role);
+				((Role) role).setDeleted(true);
 				client.dispatcher.dispatch(new RoleDeleteEvent(role, guild));
 			}
 		}

--- a/src/main/java/sx/blah/discord/api/internal/DispatchHandler.java
+++ b/src/main/java/sx/blah/discord/api/internal/DispatchHandler.java
@@ -44,7 +44,7 @@ public class DispatchHandler {
 			case "GUILD_MEMBER_ADD": guildMemberAdd(DiscordUtils.GSON.fromJson(event.get("d"), GuildMemberAddEventResponse.class)); break;
 			case "GUILD_MEMBER_REMOVE": guildMemberRemove(DiscordUtils.GSON.fromJson(event.get("d"), GuildMemberRemoveEventResponse.class)); break;
 			case "GUILD_MEMBER_UPDATE": guildMemberUpdate(DiscordUtils.GSON.fromJson(event.get("d"), GuildMemberUpdateEventResponse.class)); break;
-			case "MESSAGE_UPDATE": messageUpdate(DiscordUtils.GSON.fromJson(event.get("d"), MessageObject.class));break;
+			case "MESSAGE_UPDATE": messageUpdate(DiscordUtils.GSON.fromJson(event.get("d"), MessageObject.class)); break;
 			case "MESSAGE_DELETE": messageDelete(DiscordUtils.GSON.fromJson(event.get("d"), MessageDeleteEventResponse.class)); break;
 			case "MESSAGE_DELETE_BULK": messageDeleteBulk(DiscordUtils.GSON.fromJson(event.get("d"), MessageDeleteBulkEventResponse.class)); break;
 			case "PRESENCE_UPDATE": presenceUpdate(DiscordUtils.GSON.fromJson(event.get("d"), PresenceUpdateEventResponse.class)); break;
@@ -66,7 +66,7 @@ public class DispatchHandler {
 			case "VOICE_STATE_UPDATE": voiceStateUpdate(DiscordUtils.GSON.fromJson(event.get("d"), VoiceStateObject.class)); break;
 			case "VOICE_SERVER_UPDATE": voiceServerUpdate(DiscordUtils.GSON.fromJson(event.get("d"), VoiceUpdateResponse.class)); break;
 			case "MESSAGE_REACTION_ADD": reactionAdd(DiscordUtils.GSON.fromJson(event.get("d"), ReactionEventResponse.class)); break;
-			case "MESSAGE_REACTION_REMOVE": reactionRemove(DiscordUtils.GSON.fromJson(event.get("d"), ReactionEventResponse.class));break;
+			case "MESSAGE_REACTION_REMOVE": reactionRemove(DiscordUtils.GSON.fromJson(event.get("d"), ReactionEventResponse.class)); break;
 			case "MESSAGE_REACTION_REMOVE_ALL": /* REMOVE_ALL is 204 empty but REACTION_REMOVE is sent anyway */ break;
 
 			default:

--- a/src/main/java/sx/blah/discord/api/internal/DispatchHandler.java
+++ b/src/main/java/sx/blah/discord/api/internal/DispatchHandler.java
@@ -351,7 +351,6 @@ public class DispatchHandler {
 
 	private void guildDelete(GuildObject json) {
 		Guild guild = (Guild) client.getGuildByID(json.id);
-		guild.setDeleted(true);
 		client.getGuilds().remove(guild);
 		if (json.unavailable) { //Guild can't be reached
 			Discord4J.LOGGER.warn(LogMarkers.WEBSOCKET, "Guild with id {} is unavailable, is there an outage?", json.id);
@@ -405,7 +404,6 @@ public class DispatchHandler {
 					channel.getGuild().getChannels().remove(channel);
 				else
 					shard.privateChannels.remove(channel);
-				channel.setDeleted(true);
 				client.dispatcher.dispatch(new ChannelDeleteEvent(channel));
 			}
 		} else if (json.type.equalsIgnoreCase("voice")) {
@@ -505,7 +503,6 @@ public class DispatchHandler {
 			IRole role = guild.getRoleByID(event.role_id);
 			if (role != null) {
 				guild.getRoles().remove(role);
-				((Role) role).setDeleted(true);
 				client.dispatcher.dispatch(new RoleDeleteEvent(role, guild));
 			}
 		}

--- a/src/main/java/sx/blah/discord/handle/impl/obj/Channel.java
+++ b/src/main/java/sx/blah/discord/handle/impl/obj/Channel.java
@@ -88,10 +88,6 @@ public class Channel implements IChannel {
 	 * The client that created this object.
 	 */
 	protected final IDiscordClient client;
-	/**
-	 * Cached value of isDeleted()
-	 */
-	private volatile boolean deleted = false;
 
 	public Channel(IDiscordClient client, String name, String id, IGuild parent, String topic, int position, Map<String, PermissionOverride> roleOverrides, Map<String, PermissionOverride> userOverrides) {
 		this.client = client;
@@ -417,15 +413,6 @@ public class Channel implements IChannel {
 		roleOverrides.put(roleId, override);
 	}
 
-	/**
-	 * Sets the CACHED value of isDeleted()
-	 *
-	 * @param deleted The value to assign to isDeleted()
-	 */
-	public void setDeleted(boolean deleted){
-		this.deleted = deleted;
-	}
-
 	@Override
 	public void removePermissionsOverride(IUser user) throws MissingPermissionsException, RateLimitException, DiscordException {
 		DiscordUtils.checkPermissions(client, this, user.getRolesForGuild(parent), EnumSet.of(Permissions.MANAGE_PERMISSIONS));
@@ -529,7 +516,7 @@ public class Channel implements IChannel {
 
 	@Override
 	public boolean isDeleted() {
-		return deleted;
+		return getClient().getChannelByID(id) != this;
 	}
 
 	@Override

--- a/src/main/java/sx/blah/discord/handle/impl/obj/Channel.java
+++ b/src/main/java/sx/blah/discord/handle/impl/obj/Channel.java
@@ -516,7 +516,7 @@ public class Channel implements IChannel {
 
 	@Override
 	public boolean isDeleted() {
-		return getClient().getChannelByID(id) != this;
+		return getGuild().getChannelByID(id) != this;
 	}
 
 	@Override

--- a/src/main/java/sx/blah/discord/handle/impl/obj/Channel.java
+++ b/src/main/java/sx/blah/discord/handle/impl/obj/Channel.java
@@ -88,6 +88,10 @@ public class Channel implements IChannel {
 	 * The client that created this object.
 	 */
 	protected final IDiscordClient client;
+	/**
+	 * Cached value of isDeleted()
+	 */
+	private volatile boolean deleted = false;
 
 	public Channel(IDiscordClient client, String name, String id, IGuild parent, String topic, int position, Map<String, PermissionOverride> roleOverrides, Map<String, PermissionOverride> userOverrides) {
 		this.client = client;
@@ -413,6 +417,15 @@ public class Channel implements IChannel {
 		roleOverrides.put(roleId, override);
 	}
 
+	/**
+	 * Sets the CACHED value of isDeleted()
+	 *
+	 * @param deleted The value to assign to isDeleted()
+	 */
+	public void setDeleted(boolean deleted){
+		this.deleted = deleted;
+	}
+
 	@Override
 	public void removePermissionsOverride(IUser user) throws MissingPermissionsException, RateLimitException, DiscordException {
 		DiscordUtils.checkPermissions(client, this, user.getRolesForGuild(parent), EnumSet.of(Permissions.MANAGE_PERMISSIONS));
@@ -512,6 +525,11 @@ public class Channel implements IChannel {
 			throw new DiscordException("Message already unpinned!");
 
 		((DiscordClientImpl) client).REQUESTS.DELETE.makeRequest(DiscordEndpoints.CHANNELS + id + "/pins/" + message.getID());
+	}
+
+	@Override
+	public boolean isDeleted() {
+		return deleted;
 	}
 
 	@Override

--- a/src/main/java/sx/blah/discord/handle/impl/obj/Guild.java
+++ b/src/main/java/sx/blah/discord/handle/impl/obj/Guild.java
@@ -115,6 +115,10 @@ public class Guild implements IGuild {
 	 * The list of emojis.
 	 */
 	protected final List<IEmoji> emojis;
+	/**
+	 * Cached value of isDeleted()
+	 */
+	private volatile boolean deleted = false;
 
 	public Guild(IShard shard, String name, String id, String icon, String ownerID, String afkChannel, int afkTimeout, String region, int verification) {
 		this(shard, name, id, icon, ownerID, afkChannel, afkTimeout, region, verification, new CopyOnWriteArrayList<>(), new CopyOnWriteArrayList<>(), new CopyOnWriteArrayList<>(), new CopyOnWriteArrayList<>(), new ConcurrentHashMap<>());
@@ -664,6 +668,11 @@ public class Guild implements IGuild {
 	}
 
 	@Override
+	public boolean isDeleted() {
+		return deleted;
+	}
+
+	@Override
 	public IAudioManager getAudioManager() {
 		return audioManager;
 	}
@@ -702,6 +711,10 @@ public class Guild implements IGuild {
 		}
 
 		return message;
+	}
+
+	public void setDeleted(boolean deleted){
+		this.deleted = deleted;
 	}
 
 	@Override

--- a/src/main/java/sx/blah/discord/handle/impl/obj/Guild.java
+++ b/src/main/java/sx/blah/discord/handle/impl/obj/Guild.java
@@ -115,10 +115,6 @@ public class Guild implements IGuild {
 	 * The list of emojis.
 	 */
 	protected final List<IEmoji> emojis;
-	/**
-	 * Cached value of isDeleted()
-	 */
-	private volatile boolean deleted = false;
 
 	public Guild(IShard shard, String name, String id, String icon, String ownerID, String afkChannel, int afkTimeout, String region, int verification) {
 		this(shard, name, id, icon, ownerID, afkChannel, afkTimeout, region, verification, new CopyOnWriteArrayList<>(), new CopyOnWriteArrayList<>(), new CopyOnWriteArrayList<>(), new CopyOnWriteArrayList<>(), new ConcurrentHashMap<>());
@@ -669,7 +665,7 @@ public class Guild implements IGuild {
 
 	@Override
 	public boolean isDeleted() {
-		return deleted;
+		return getClient().getGuildByID(id) != this;
 	}
 
 	@Override
@@ -711,10 +707,6 @@ public class Guild implements IGuild {
 		}
 
 		return message;
-	}
-
-	public void setDeleted(boolean deleted){
-		this.deleted = deleted;
 	}
 
 	@Override

--- a/src/main/java/sx/blah/discord/handle/impl/obj/Message.java
+++ b/src/main/java/sx/blah/discord/handle/impl/obj/Message.java
@@ -567,9 +567,9 @@ public class Message implements IMessage {
 	}
 
 	/**
-	 * Sets the CACHED deleted value
+	 * Sets the CACHED deleted value.
 	 *
-	 * @param deleted The value to assign into the cache
+	 * @param deleted The value to assign into the cache.
 	 */
 	public void setDeleted(boolean deleted) {
 		this.deleted = deleted;

--- a/src/main/java/sx/blah/discord/handle/impl/obj/Message.java
+++ b/src/main/java/sx/blah/discord/handle/impl/obj/Message.java
@@ -125,7 +125,7 @@ public class Message implements IMessage {
 	/**
 	 * Cached value of isDeleted()
 	 */
-	private boolean deleted = false;
+	private volatile boolean deleted = false;
 
 	public Message(IDiscordClient client, String id, String content, IUser user, IChannel channel,
 				   LocalDateTime timestamp, LocalDateTime editedTimestamp, boolean mentionsEveryone,
@@ -290,7 +290,7 @@ public class Message implements IMessage {
 	public IMessage edit(String content) throws MissingPermissionsException, RateLimitException, DiscordException {
 		if (!this.getAuthor().equals(client.getOurUser()))
 			throw new MissingPermissionsException("Cannot edit other users' messages!");
-		if(isDeleted())
+		if (isDeleted())
 			throw new DiscordException("Cannot edit deleted messages!");
 		if (client.isReady()) {
 //			content = DiscordUtils.escapeString(content);

--- a/src/main/java/sx/blah/discord/handle/impl/obj/PrivateChannel.java
+++ b/src/main/java/sx/blah/discord/handle/impl/obj/PrivateChannel.java
@@ -167,4 +167,9 @@ public class PrivateChannel extends Channel implements IPrivateChannel {
 	public IPrivateChannel copy() {
 		return new PrivateChannel(client, recipient, id);
 	}
+
+	@Override
+	public boolean isDeleted() {
+		return getClient().getChannelByID(id) != this;
+	}
 }

--- a/src/main/java/sx/blah/discord/handle/impl/obj/PrivateChannel.java
+++ b/src/main/java/sx/blah/discord/handle/impl/obj/PrivateChannel.java
@@ -170,6 +170,6 @@ public class PrivateChannel extends Channel implements IPrivateChannel {
 
 	@Override
 	public boolean isDeleted() {
-		return getClient().getChannelByID(id) != this;
+		return false;
 	}
 }

--- a/src/main/java/sx/blah/discord/handle/impl/obj/Role.java
+++ b/src/main/java/sx/blah/discord/handle/impl/obj/Role.java
@@ -71,10 +71,6 @@ public class Role implements IRole {
 	 * The guild this role belongs to
 	 */
 	protected volatile IGuild guild;
-	/**
-	 * Cached value of isDeleted()
-	 */
-	private volatile boolean deleted = false;
 
 	public Role(int position, int permissions, String name, boolean managed, String id, boolean hoist, int color, boolean mentionable, IGuild guild) {
 		this.position = position;
@@ -263,7 +259,7 @@ public class Role implements IRole {
 
 	@Override
 	public boolean isDeleted() {
-		return deleted;
+		return getClient().getRoleByID(id) != this;
 	}
 
 	@Override
@@ -287,9 +283,5 @@ public class Role implements IRole {
 			return false;
 
 		return this.getClass().isAssignableFrom(other.getClass()) && ((IRole) other).getID().equals(getID());
-	}
-
-	public void setDeleted(boolean deleted) {
-		this.deleted = deleted;
 	}
 }

--- a/src/main/java/sx/blah/discord/handle/impl/obj/Role.java
+++ b/src/main/java/sx/blah/discord/handle/impl/obj/Role.java
@@ -259,7 +259,7 @@ public class Role implements IRole {
 
 	@Override
 	public boolean isDeleted() {
-		return getClient().getRoleByID(id) != this;
+		return getGuild().getRoleByID(id) != this;
 	}
 
 	@Override

--- a/src/main/java/sx/blah/discord/handle/impl/obj/Role.java
+++ b/src/main/java/sx/blah/discord/handle/impl/obj/Role.java
@@ -1,7 +1,6 @@
 package sx.blah.discord.handle.impl.obj;
 
 import org.apache.http.entity.StringEntity;
-import org.apache.http.message.BasicNameValuePair;
 import sx.blah.discord.Discord4J;
 import sx.blah.discord.api.IDiscordClient;
 import sx.blah.discord.api.IShard;
@@ -9,15 +8,15 @@ import sx.blah.discord.api.internal.DiscordClientImpl;
 import sx.blah.discord.api.internal.DiscordEndpoints;
 import sx.blah.discord.api.internal.DiscordUtils;
 import sx.blah.discord.api.internal.json.objects.RoleObject;
+import sx.blah.discord.api.internal.json.requests.RoleEditRequest;
 import sx.blah.discord.handle.impl.events.RoleUpdateEvent;
 import sx.blah.discord.handle.obj.IGuild;
 import sx.blah.discord.handle.obj.IRole;
 import sx.blah.discord.handle.obj.Permissions;
-import sx.blah.discord.api.internal.json.requests.RoleEditRequest;
 import sx.blah.discord.util.DiscordException;
-import sx.blah.discord.util.RateLimitException;
 import sx.blah.discord.util.LogMarkers;
 import sx.blah.discord.util.MissingPermissionsException;
+import sx.blah.discord.util.RateLimitException;
 
 import java.awt.*;
 import java.io.UnsupportedEncodingException;
@@ -72,6 +71,10 @@ public class Role implements IRole {
 	 * The guild this role belongs to
 	 */
 	protected volatile IGuild guild;
+	/**
+	 * Cached value of isDeleted()
+	 */
+	private volatile boolean deleted = false;
 
 	public Role(int position, int permissions, String name, boolean managed, String id, boolean hoist, int color, boolean mentionable, IGuild guild) {
 		this.position = position;
@@ -259,6 +262,11 @@ public class Role implements IRole {
 	}
 
 	@Override
+	public boolean isDeleted() {
+		return deleted;
+	}
+
+	@Override
 	public String mention() {
 		return isMentionable() ? (isEveryoneRole() ? "@everyone" : "<@&"+id+">") : name;
 	}
@@ -279,5 +287,9 @@ public class Role implements IRole {
 			return false;
 
 		return this.getClass().isAssignableFrom(other.getClass()) && ((IRole) other).getID().equals(getID());
+	}
+
+	public void setDeleted(boolean deleted) {
+		this.deleted = deleted;
 	}
 }

--- a/src/main/java/sx/blah/discord/handle/impl/obj/VoiceChannel.java
+++ b/src/main/java/sx/blah/discord/handle/impl/obj/VoiceChannel.java
@@ -1,19 +1,21 @@
 package sx.blah.discord.handle.impl.obj;
 
 import org.apache.http.entity.StringEntity;
-import org.apache.http.message.BasicNameValuePair;
 import sx.blah.discord.Discord4J;
 import sx.blah.discord.api.IDiscordClient;
 import sx.blah.discord.api.internal.*;
 import sx.blah.discord.api.internal.json.objects.ChannelObject;
+import sx.blah.discord.api.internal.json.requests.ChannelEditRequest;
 import sx.blah.discord.api.internal.json.requests.voice.VoiceChannelJoinRequest;
 import sx.blah.discord.handle.impl.events.ChannelUpdateEvent;
 import sx.blah.discord.handle.impl.events.VoiceDisconnectedEvent;
 import sx.blah.discord.handle.obj.*;
-import sx.blah.discord.api.internal.json.requests.ChannelEditRequest;
 import sx.blah.discord.util.*;
 
-import java.io.*;
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.InputStream;
+import java.io.UnsupportedEncodingException;
 import java.util.*;
 import java.util.stream.Collectors;
 
@@ -225,5 +227,10 @@ public class VoiceChannel extends Channel implements IVoiceChannel {
 	@Override
 	public String toString(){
 		return getName();
+	}
+
+	@Override
+	public boolean isDeleted() {
+		return getGuild().getVoiceChannelByID(getID()) != this;
 	}
 }

--- a/src/main/java/sx/blah/discord/handle/obj/IChannel.java
+++ b/src/main/java/sx/blah/discord/handle/obj/IChannel.java
@@ -122,7 +122,7 @@ public interface IChannel extends IDiscordObject<IChannel> {
 
 	/**
 	 * Uploads an InputStream to the channel with an attached message and option for tts.
-	 * 
+	 *
 	 * @param content The content of the attached message.
 	 * @param tts Whether the message should use tts or not.
 	 * @param file The input stream to upload.
@@ -341,6 +341,13 @@ public interface IChannel extends IDiscordObject<IChannel> {
 	 * @throws MissingPermissionsException
 	 */
 	void unpin(IMessage message) throws RateLimitException, DiscordException, MissingPermissionsException;
+
+	/**
+	 * Checks to see if the this channel is deleted.
+	 *
+	 * @return True if this channel is deleted.
+	 */
+	boolean isDeleted();
 
 	/**
 	 * Represents specific permission overrides for a user/role in the channel.

--- a/src/main/java/sx/blah/discord/handle/obj/IGuild.java
+++ b/src/main/java/sx/blah/discord/handle/obj/IGuild.java
@@ -472,6 +472,13 @@ public interface IGuild extends IDiscordObject<IGuild> {
 	int pruneUsers(int days) throws DiscordException, RateLimitException;
 
 	/**
+	 * Checks to see if the this guild is deleted.
+	 *
+	 * @return True if this guild is deleted.
+	 */
+	boolean isDeleted();
+
+	/**
 	 * Gets the {@link AudioManager} instance for this guild.
 	 *
 	 * @return The audio manager for this guild.

--- a/src/main/java/sx/blah/discord/handle/obj/IMessage.java
+++ b/src/main/java/sx/blah/discord/handle/obj/IMessage.java
@@ -225,7 +225,7 @@ public interface IMessage extends IDiscordObject<IMessage> {
 	 * @throws MissingPermissionsException
 	 * @throws RateLimitException
 	 * @throws DiscordException
-	 * @[param user The user
+	 * @param user The user
 	 */
 	void removeReaction(IUser user, IReaction reaction) throws MissingPermissionsException, RateLimitException, DiscordException;
 

--- a/src/main/java/sx/blah/discord/handle/obj/IMessage.java
+++ b/src/main/java/sx/blah/discord/handle/obj/IMessage.java
@@ -222,10 +222,10 @@ public interface IMessage extends IDiscordObject<IMessage> {
 	 * Removes a reaction for a user.
 	 *
 	 * @param reaction The reaction to remove from
+	 * @param user The user
 	 * @throws MissingPermissionsException
 	 * @throws RateLimitException
 	 * @throws DiscordException
-	 * @param user The user
 	 */
 	void removeReaction(IUser user, IReaction reaction) throws MissingPermissionsException, RateLimitException, DiscordException;
 

--- a/src/main/java/sx/blah/discord/handle/obj/IMessage.java
+++ b/src/main/java/sx/blah/discord/handle/obj/IMessage.java
@@ -97,7 +97,6 @@ public interface IMessage extends IDiscordObject<IMessage> {
 	 *
 	 * @param content The new content for the message to contain.
 	 * @return The new message (this).
-	 *
 	 * @throws MissingPermissionsException
 	 * @throws DiscordException
 	 */
@@ -163,6 +162,7 @@ public interface IMessage extends IDiscordObject<IMessage> {
 
 	/**
 	 * Gets a reaction by the IEmoji object.
+	 *
 	 * @param emoji The emoji
 	 * @return The reaction, or null if there aren't any that match
 	 */
@@ -199,7 +199,7 @@ public interface IMessage extends IDiscordObject<IMessage> {
 	/**
 	 * Adds your reaction as a custom emoji
 	 *
-	 * @param emoji   The custom emoji
+	 * @param emoji The custom emoji
 	 * @throws MissingPermissionsException
 	 * @throws RateLimitException
 	 * @throws DiscordException
@@ -210,7 +210,7 @@ public interface IMessage extends IDiscordObject<IMessage> {
 	/**
 	 * Adds your reaction as a normal emoji. This can be either a Unicode emoji, or an IEmoji formatted one (&lt;:name:id&gt;)
 	 *
-	 * @param emoji   The string emoji
+	 * @param emoji The string emoji
 	 * @throws MissingPermissionsException
 	 * @throws RateLimitException
 	 * @throws DiscordException
@@ -221,11 +221,11 @@ public interface IMessage extends IDiscordObject<IMessage> {
 	/**
 	 * Removes a reaction for a user.
 	 *
-	 * @[param user The user
 	 * @param reaction The reaction to remove from
 	 * @throws MissingPermissionsException
 	 * @throws RateLimitException
 	 * @throws DiscordException
+	 * @[param user The user
 	 */
 	void removeReaction(IUser user, IReaction reaction) throws MissingPermissionsException, RateLimitException, DiscordException;
 
@@ -238,6 +238,13 @@ public interface IMessage extends IDiscordObject<IMessage> {
 	 * @throws DiscordException
 	 */
 	void removeReaction(IReaction reaction) throws MissingPermissionsException, RateLimitException, DiscordException;
+
+	/**
+	 * Checks to see is this message deleted.
+	 *
+	 * @return True if this message is deleted
+	 */
+	boolean isDeleted();
 
 	/**
 	 * Represents an attachment included in the message.
@@ -307,6 +314,7 @@ public interface IMessage extends IDiscordObject<IMessage> {
 			return url;
 		}
 	}
+
 	interface IEmbedded {
 
 		/**

--- a/src/main/java/sx/blah/discord/handle/obj/IRole.java
+++ b/src/main/java/sx/blah/discord/handle/obj/IRole.java
@@ -131,14 +131,20 @@ public interface IRole extends IDiscordObject<IRole> {
 	 * @throws DiscordException
 	 */
 	void delete() throws MissingPermissionsException, RateLimitException, DiscordException;
-	
+
 	/**
 	 * This checks if the role is the @everyone role.
 	 *
 	 * @return True if the @everyone role, false if otherwise.
 	 */
 	boolean isEveryoneRole();
-	
+
+	/**
+	 * Checks to see if the this role is deleted.
+	 *
+	 * @return True if this role is deleted.
+	 */
+	boolean isDeleted();
 	/**
 	 * Formats a string to @mention the role.
 	 *


### PR DESCRIPTION
### Prerequisites
* [x] I have read and understood the [contribution guidelines](CONTRIBUTING.md)
* [x] This pull request follows the code style of the project
* [x] I have tested this feature thoroughly
  * [Proof of testing](http://i.imgur.com/9wl3Ilb.png)

**Issues Fixed:** Before these changes were made, trying to edit a deleted message would result in a null pointer exception. What I've done is added isDeleted() boolean and a check to the edit() function. 

### Changes Proposed in this Pull Request
* Add isDeleted()
* Make a check which throws a DiscordException when trying to edit a deleted message