### PR TITLE
Filter out invalid invites, so we don't get null pointers

### DIFF
--- a/src/main/java/sx/blah/discord/api/internal/DiscordUtils.java
+++ b/src/main/java/sx/blah/discord/api/internal/DiscordUtils.java
@@ -108,6 +108,8 @@ public class DiscordUtils {
 	 * @return The java invite object.
 	 */
 	public static IInvite getInviteFromJSON(IDiscordClient client, InviteObject json) {
+		if(json == null)
+			return null;
 		return new Invite(client, json.code);
 	}
 

--- a/src/main/java/sx/blah/discord/api/internal/DispatchHandler.java
+++ b/src/main/java/sx/blah/discord/api/internal/DispatchHandler.java
@@ -10,13 +10,12 @@ import sx.blah.discord.api.internal.json.responses.voice.VoiceUpdateResponse;
 import sx.blah.discord.handle.impl.events.*;
 import sx.blah.discord.handle.impl.obj.*;
 import sx.blah.discord.handle.obj.*;
-import sx.blah.discord.util.*;
+import sx.blah.discord.util.LogMarkers;
+import sx.blah.discord.util.MessageList;
+import sx.blah.discord.util.RequestBuilder;
 
 import java.time.LocalDateTime;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Optional;
+import java.util.*;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
@@ -156,7 +155,10 @@ class DispatchHandler {
 
 				List<String> inviteCodes = DiscordUtils.getInviteCodesFromMessage(json.content);
 				if (!inviteCodes.isEmpty()) {
-					List<IInvite> invites = inviteCodes.stream().map(s -> client.getInviteForCode(s)).collect(Collectors.toList());
+					List<IInvite> invites = inviteCodes.stream()
+							.map(s -> client.getInviteForCode(s))
+							.filter(Objects::nonNull)
+							.collect(Collectors.toList());
 					client.getDispatcher().dispatch(new InviteReceivedEvent(invites.toArray(new IInvite[invites.size()]), message));
 				}
 


### PR DESCRIPTION
### Prerequisites
* [x] I have read and understood the [contribution guidelines](CONTRIBUTING.md)
* [x] This pull request follows the code style of the project
* [x] I have tested this feature thoroughly
  * [Proof of testing](http://imgur.com/gallery/AmVAT)

**Issues Fixed:** Upon sending an invalid invite a null pointer would occur preventing message recieve event. 

### Changes Proposed in this Pull Request
* Add a null check and filter out null invites