### PR TITLE
Fix bot token prefixation when sending a PATCH request to edit account data

### DIFF
--- a/src/main/java/sx/blah/discord/api/internal/DiscordClientImpl.java
+++ b/src/main/java/sx/blah/discord/api/internal/DiscordClientImpl.java
@@ -8,19 +8,22 @@ import sx.blah.discord.api.events.EventDispatcher;
 import sx.blah.discord.api.internal.json.objects.InviteObject;
 import sx.blah.discord.api.internal.json.objects.UserObject;
 import sx.blah.discord.api.internal.json.objects.VoiceRegionObject;
-import sx.blah.discord.handle.impl.events.LoginEvent;
+import sx.blah.discord.api.internal.json.requests.AccountInfoChangeRequest;
+import sx.blah.discord.api.internal.json.responses.AccountInfoChangeResponse;
+import sx.blah.discord.api.internal.json.responses.ApplicationInfoResponse;
+import sx.blah.discord.api.internal.json.responses.GatewayResponse;
 import sx.blah.discord.handle.impl.events.ReadyEvent;
 import sx.blah.discord.handle.impl.events.ShardReadyEvent;
 import sx.blah.discord.handle.impl.obj.User;
 import sx.blah.discord.handle.obj.*;
-import sx.blah.discord.api.internal.json.requests.*;
-import sx.blah.discord.api.internal.json.responses.*;
 import sx.blah.discord.modules.ModuleLoader;
 import sx.blah.discord.util.*;
 
 import java.io.UnsupportedEncodingException;
 import java.util.*;
-import java.util.concurrent.*;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
 /**
@@ -151,9 +154,9 @@ public final class DiscordClientImpl implements IDiscordClient {
 					new StringEntity(DiscordUtils.GSON.toJson(new AccountInfoChangeRequest(username, avatar))));
 			AccountInfoChangeResponse response = DiscordUtils.GSON.fromJson(json, AccountInfoChangeResponse.class);
 
-			if (!this.getToken().equals(response.token)) {
+			if (!this.getToken().equals("Bot " + response.token)) {
 				Discord4J.LOGGER.debug(LogMarkers.API, "Token changed, updating it.");
-				this.token = response.token;
+				this.token = "Bot " + response.token;
 			}
 		} catch (UnsupportedEncodingException e) {
 			Discord4J.LOGGER.error(LogMarkers.API, "Discord4J Internal Exception", e);


### PR DESCRIPTION
### Prerequisites
* [x] I have read and understood the [contribution guidelines](CONTRIBUTING.md)
* [x] This pull request follows the code style of the project
* [x] I have tested this feature thoroughly
  * [Proof of testing](http://i.imgur.com/EZSpkOq.gif)

**Issues Fixed:** Due to a recent update to the PATCH request which updates the client data the token check would break. This PR will just prepend `Bot ` back to the token.

### Changes Proposed in this Pull Request
* Prepend `Bot ` in the token change check
* Prepend `Bot ` in the token changed variable set