### PR TITLE
Fix for #166 ConcurrentModificationException while dispatching GuildCreateEvent

### DIFF
--- a/src/main/java/sx/blah/discord/api/internal/DispatchHandler.java
+++ b/src/main/java/sx/blah/discord/api/internal/DispatchHandler.java
@@ -95,7 +95,9 @@ class DispatchHandler {
 			ArrayList<UnavailableGuildObject> waitingGuilds = new ArrayList<>(Arrays.asList(ready.guilds));
 			for (int i = 0; i < ready.guilds.length; i++) {
 				client.getDispatcher().waitFor((GuildCreateEvent e) -> {
-					waitingGuilds.removeIf(g -> g.id.equals(e.getGuild().getID()));
+					synchronized (waitingGuilds) {
+						waitingGuilds.removeIf(g -> g.id.equals(e.getGuild().getID()));
+					}
 					return true;
 				}, 10, TimeUnit.SECONDS);
 			}


### PR DESCRIPTION
### Prerequisites
* [x] I have read and understood the [contribution guidelines](CONTRIBUTING.md)
* [x] This pull request follows the code style of the project
* [x] I have tested this feature thoroughly

This pull request should fix #166 where a ConcurrentModificationException is thrown while dispatching a GuildCreateEvent. Since I have made this change locally, I have not encountered this error at all on my main bot with over 1400 servers, and I have tested it on a bot with around 10 servers to make sure my change did not affect smaller bots.

Changes:
* Added a synchronized block while iterating over an ArrayList of guild objects