### PR TITLE
Fix reconnecting on logout

### DIFF
--- a/src/main/java/sx/blah/discord/api/internal/DiscordWS.java
+++ b/src/main/java/sx/blah/discord/api/internal/DiscordWS.java
@@ -161,13 +161,14 @@ public class DiscordWS extends WebSocketAdapter {
 
 	void shutdown() {
 		Discord4J.LOGGER.debug(LogMarkers.WEBSOCKET, "Shard {} shutting down.", shard.getInfo()[0]);
+		this.state = State.DISCONNECTING;
+
 		try {
 			heartbeatHandler.shutdown();
 			getSession().close(1000, null); // Discord doesn't care about the reason
 			wsClient.stop();
 			hasReceivedReady = false;
 			isReady = false;
-			this.state = State.IDLE;
 		} catch (Exception e) {
 			Discord4J.LOGGER.error(LogMarkers.WEBSOCKET, "Error while shutting down websocket: ", e);
 		}


### PR DESCRIPTION
### Prerequisites
* [x] I have read and understood the [contribution guidelines](CONTRIBUTING.md)
* [x] This pull request follows the code style of the project
* [x] I have tested this feature thoroughly
  * [Proof of testing](https://gist.github.com/theIglooo/ecedac8d8fb25e7dfca6613059a74bcf)

**Issues Fixed:** Reported in the bug-reports channel, Discord4J would attempt to reconnect on logouts because it had the wrong state set when logging out.

### Changes Proposed in this Pull Request
* Changes the state from IDLE to DISCONNECTING
* Moves the state change above the other code in DiscordWS#shutdown