### PR TITLE
Add support for discord recommended shard count

### DIFF
--- a/src/main/java/sx/blah/discord/Discord4J.java
+++ b/src/main/java/sx/blah/discord/Discord4J.java
@@ -177,10 +177,10 @@ public class Discord4J {
 			throw new RuntimeException("Invalid configuration!");
 		try {
 			ClientBuilder builder = new ClientBuilder();
-			IDiscordClient client = builder.withToken(args[0]).login();
-			client.getDispatcher().registerListener((IListener<ReadyEvent>) (ReadyEvent e) -> {
-				LOGGER.info(LogMarkers.MAIN, "Logged in as {}", e.getClient().getOurUser().getName());
+			builder.registerListener((IListener<ReadyEvent>) event -> {
+				LOGGER.info(LogMarkers.MAIN, "Logged in as {}", event.getClient().getOurUser().getName());
 			});
+			builder.withToken(args[0]).login();
 			//The modules should handle the rest
 		} catch (DiscordException e) {
 			LOGGER.error(LogMarkers.MAIN, "There was an error initializing the client", e);

--- a/src/main/java/sx/blah/discord/api/ClientBuilder.java
+++ b/src/main/java/sx/blah/discord/api/ClientBuilder.java
@@ -8,6 +8,8 @@ import sx.blah.discord.util.DiscordException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import sx.blah.discord.modules.Configuration;
+import sx.blah.discord.modules.ModuleLoader;
 
 /**
  * Use this as a factory to create {@link IDiscordClient} instances
@@ -245,6 +247,9 @@ public class ClientBuilder {
 			throw new DiscordException("No login info present!");
 
 		final IDiscordClient client = new DiscordClientImpl(this);
+                if (Configuration.AUTOMATICALLY_ENABLE_MODULES) { // Need to be sure a module instance is create.
+                    ModuleLoader.getForClient(client);
+                }
 
 		//Registers events as soon as client is initialized
 		final EventDispatcher dispatcher = client.getDispatcher();

--- a/src/main/java/sx/blah/discord/api/ClientBuilder.java
+++ b/src/main/java/sx/blah/discord/api/ClientBuilder.java
@@ -14,6 +14,7 @@ import java.util.List;
  */
 public class ClientBuilder {
 
+        private boolean recommendShardCount = false;
 	private int maxMissedPings = -1;
 	private String botToken;
 	private boolean isDaemon = false;
@@ -56,6 +57,15 @@ public class ClientBuilder {
 		this.maxMissedPings = maxMissedPings;
 		return this;
 	}
+        
+        /**
+         * Gets the current ping timeout.
+         * 
+         * @return The ping timeout.
+         */
+        public int getPingTimeout() {
+                return maxMissedPings;
+        }
 
 	/**
 	 * Sets whether the client should act as a daemon (it is NOT a daemon by default).
@@ -68,9 +78,19 @@ public class ClientBuilder {
 		this.isDaemon = isDaemon;
 		return this;
 	}
+        
+        /**
+         * Gets the current daemon state.
+         * 
+         * @return The daemon state.
+         */
+        public boolean isDaemon() {
+                return isDaemon;
+        }
 
 	/**
-	 * Sets the sharding information for the client.
+	 * Sets the number of shards to use when the client logs in.
+         * 
 	 * @param shardCount The total number of shards that will be created.
 	 * @return The instance of the builder.
 	 */
@@ -78,6 +98,36 @@ public class ClientBuilder {
 		this.shardCount = shardCount;
 		return this;
 	}
+        
+        /**
+         * Gets the current shard count.
+         * 
+         * @return The shard count.
+         */
+        public int getShardCount() {
+                return shardCount;
+        }
+        
+        /**
+         * Sets whether the client should use the recommended shard count received when logging in. Note: enabling this
+         * option will ignore the shard count set with {@link #withShards(int shardCount)}. This is false by default.
+         * 
+         * @param recommendShardCount True to use to recommended shard count, false otherwise.
+         * @return The instance of the builder.
+         */
+        public ClientBuilder useRecommendedShardCount(boolean recommendShardCount) {
+                this.recommendShardCount = recommendShardCount;
+                return this;
+        }
+        
+        /**
+         * Gets the current state of using a recommended shard count.
+         * 
+         * @return True if using recommended shard count, false otherwise.
+         */
+        public boolean isRecommendingShardCount() {
+                return recommendShardCount;
+        }
 
 	/**
 	 * Sets the max amount of attempts shards managed by this client will make to reconnect in the event of an
@@ -90,6 +140,15 @@ public class ClientBuilder {
 		this.maxReconnectAttempts = maxReconnectAttempts;
 		return this;
 	}
+        
+        /**
+         * Gets the current maximum reconnect attempts.
+         * 
+         * @return The maximum reconnect attempts.
+         */
+        public int getMaxReconnectAttempts() {
+                return maxReconnectAttempts;
+        }
 
 	/**
 	 * This registers event listeners before the client is logged in.
@@ -164,19 +223,28 @@ public class ClientBuilder {
 		this.retryCount = retryCount;
 		return this;
 	}
+        
+        /**
+         * Gets the current 5xx retry count.
+         * 
+         * @return The 5xx retry count.
+         */
+        public int get5xxRetryCount() {
+                return retryCount;
+        }
 
 	/**
-	 * Creates the discord instance with the desired features
+	 * Creates the discord instance with the desired features.
 	 *
-	 * @return The discord instance
+	 * @return The discord instance.
 	 *
-	 * @throws DiscordException Thrown if the instance isn't built correctly
+	 * @throws DiscordException Thrown if the instance isn't built correctly.
 	 */
 	public IDiscordClient build() throws DiscordException {
 		if (botToken == null)
 			throw new DiscordException("No login info present!");
 
-		final IDiscordClient client = new DiscordClientImpl(botToken, shardCount, isDaemon, maxMissedPings, maxReconnectAttempts, retryCount);
+		final IDiscordClient client = new DiscordClientImpl(this);
 
 		//Registers events as soon as client is initialized
 		final EventDispatcher dispatcher = client.getDispatcher();
@@ -188,11 +256,11 @@ public class ClientBuilder {
 	}
 
 	/**
-	 * Performs {@link #build()} and logs in automatically
+	 * Performs {@link #build()} and logs in automatically.
 	 *
-	 * @return The discord instance
+	 * @return The discord instance.
 	 *
-	 * @throws DiscordException Thrown if the instance isn't built correctly
+	 * @throws DiscordException Thrown if the instance isn't built correctly.
 	 */
 	public IDiscordClient login() throws DiscordException {
 		IDiscordClient client = build();

--- a/src/main/java/sx/blah/discord/api/internal/DiscordClientImpl.java
+++ b/src/main/java/sx/blah/discord/api/internal/DiscordClientImpl.java
@@ -60,11 +60,6 @@ public final class DiscordClientImpl implements IDiscordClient {
 	volatile ReconnectManager reconnectManager;
 
 	/**
-	 * The module loader for this client.
-	 */
-	private volatile ModuleLoader loader;
-
-	/**
 	 * Caches the available regions for discord.
 	 */
 	private final List<IRegion> REGIONS = new CopyOnWriteArrayList<>();
@@ -113,7 +108,6 @@ public final class DiscordClientImpl implements IDiscordClient {
                 this.recommendShardCount = false;
 		this.dispatcher = new EventDispatcher(this);
 		this.reconnectManager = new ReconnectManager(this, maxReconnectAttempts);
-		this.loader = new ModuleLoader(this);
 		
 		final DiscordClientImpl instance = this;
 		Runtime.getRuntime().addShutdownHook(new Thread(() -> {
@@ -131,7 +125,6 @@ public final class DiscordClientImpl implements IDiscordClient {
                 this.recommendShardCount = builder.isRecommendingShardCount();
 		this.dispatcher = new EventDispatcher(this);
 		this.reconnectManager = new ReconnectManager(this, builder.getMaxReconnectAttempts());
-		this.loader = new ModuleLoader(this);
 		
 		final DiscordClientImpl instance = this;
 		Runtime.getRuntime().addShutdownHook(new Thread(() -> {
@@ -160,7 +153,7 @@ public final class DiscordClientImpl implements IDiscordClient {
 
 	@Override
 	public ModuleLoader getModuleLoader() {
-		return this.loader;
+		return ModuleLoader.getForClient(this);
 	}
 
 	@Override

--- a/src/main/java/sx/blah/discord/api/internal/DiscordEndpoints.java
+++ b/src/main/java/sx/blah/discord/api/internal/DiscordEndpoints.java
@@ -26,9 +26,11 @@ public final class DiscordEndpoints {
 	public static final String APIBASE = BASE+"api";
 
 	public static final String GATEWAY = APIBASE+"/gateway";
+        
+	public static final String GATEWAY_BOT = GATEWAY+"/bot";
 
 	public static final String USERS = APIBASE+"/users/";
-
+        
 	/**
 	 * Used for logging in.
 	 */

--- a/src/main/java/sx/blah/discord/api/internal/json/responses/GatewayBotResponse.java
+++ b/src/main/java/sx/blah/discord/api/internal/json/responses/GatewayBotResponse.java
@@ -1,0 +1,12 @@
+package sx.blah.discord.api.internal.json.responses;
+
+/**
+ * The response received when obtaining a websocket url with recommended shards count
+ */
+public class GatewayBotResponse extends GatewayResponse {
+        
+        /**
+	 * The recommended number of shards to connect with
+	 */
+        public int shards;
+}


### PR DESCRIPTION
### Prerequisites
* [x] I have read and understood the [contribution guidelines](CONTRIBUTING.md)
* [x] This pull request follows the code style of the project
* [x] I have tested this feature thoroughly
   * [Proof of testing](https://gist.github.com/arcadeena/ea134e72c3ca749f9633e296e5ca26e9) Add support for discord recommended shard count. Note: tested for a client with 1 shard however the [discord docs](https://discordapp.com/developers/docs/topics/gateway#get-gateway) shouldn't be wrong and work when more are required.
   * [Proof of testing](https://gist.github.com/arcadeena/d8805fd785d32a1e8600546426969859) Fix for potential NullPointerException in ModuleLoader. Proof with and without the thrown exception between versions.

**Issues Fixed:** Main method client is logging in before registering the ready listener. This was never a realistic issue but a nice change. A NullPointerException is thrown when a module would access the ModuleLoader after being enabled automatically. Automatic enabling would also lead to an infinite loop if the Requires annotation value is missing or invalid.

### Changes Proposed in this Pull Request
- Register ready listener before login
- Create client fully before attempting to load modules automatically
- Add check for (and log) missing or invalid Requires annotation dependencies.
- Treat ModuleLoader more like AudioPlayer then core dependency 
  - Add static method ModuleLoader#getForClient
  - Only create ModuleLoader instance when required
- Add #get methods in ClientBuilder for all variables (not just token)
- New ClientBuilder option for discord recommended shard count
    - Adds the required DiscordEndpoint variable
    - Adds the json response object (extends GatewayResponse)
    - Changes some checks in the DiscordClientImpl class to account for the option

**Note:** this change wouldn't conflict with any existing ClientBuilder or DiscordClientImpl projects/sources. This does however come with the cost of adding a new (future proof) constructor to DiscordClientImpl (giving it the builder) to initialise with the builder options. This is why the ClientBuilder class would require get methods for all options.