### PR TITLE
Don't reconnect on graceful jetty shutdowns

### DIFF
--- a/src/main/java/sx/blah/discord/api/internal/DiscordWS.java
+++ b/src/main/java/sx/blah/discord/api/internal/DiscordWS.java
@@ -118,7 +118,7 @@ public class DiscordWS extends WebSocketAdapter {
 		Discord4J.LOGGER.info(LogMarkers.WEBSOCKET, "Shard {} websocket disconnected with status code {} and reason \"{}\".", shard.getInfo()[0], statusCode, reason);
 
 		heartbeatHandler.shutdown();
-		if (this.state != State.DISCONNECTING && statusCode != 4003 && statusCode != 4004 && statusCode != 4005 && statusCode != 4010) {
+		if (this.state != State.DISCONNECTING && statusCode != 4003 && statusCode != 4004 && statusCode != 4005 && statusCode != 4010 && (statusCode == 1001 ^ reason.equals("Shutdown"))) {
 			this.state = State.RESUMING;
 			client.getDispatcher().dispatch(new DisconnectedEvent(DisconnectedEvent.Reason.ABNORMAL_CLOSE, shard));
 			client.reconnectManager.scheduleReconnect(this);


### PR DESCRIPTION
Every time I close an application via CTRL-C or ![exit](https://dl.dropboxusercontent.com/s/32xxrfleerk3cof/idea_2017-01-25_00-27-00.png) "Exit" button under IntelliJ run panel, the last log lines I see before the JVM shutdowns, are attempts from Discord4J to reconnect the bot, most of the time succeeding, only to just be killed shortly afterwards.

The source is [Jetty issuing a 1001 code + "Shutdown" reason](https://github.com/eclipse/jetty.project/blob/jetty-9.4.x/jetty-websocket/websocket-common/src/main/java/org/eclipse/jetty/websocket/common/WebSocketSession.java#L169) whenever this happens, which is not caught by the WS who interprets this as grounds for a normal reconnect. This PR adds a minor check that allows this type of shutdowns to be completed properly.

I hope it doesn't conflict with any of the potential codes that might come from Discord. No additional logic/events added for this type of disconnects.

### Prerequisites
* [x] I have read and understood the [contribution guidelines](CONTRIBUTING.md)
* [x] This pull request follows the code style of the project
* [x] I have tested this feature thoroughly
  * [Proof of testing](https://gist.github.com/quanticc/f52174d007ae464c1d57a7617c4e4b4c) shows normal logout, ctrl+c and ctrl+c without the changes.

**Issues Fixed:**
* Reconnect attempted when closing application via CTRL-C

### Changes Proposed in this Pull Request
* Add a check to DiscordWS#onWebSocketClose to not attempt reconnects on graceful shutdowns
