### PR TITLE
Fix for not reconnecting on jetty shutdown (part II)

### DIFF
--- a/src/main/java/sx/blah/discord/api/internal/DiscordWS.java
+++ b/src/main/java/sx/blah/discord/api/internal/DiscordWS.java
@@ -118,7 +118,7 @@ public class DiscordWS extends WebSocketAdapter {
 		Discord4J.LOGGER.info(LogMarkers.WEBSOCKET, "Shard {} websocket disconnected with status code {} and reason \"{}\".", shard.getInfo()[0], statusCode, reason);
 
 		heartbeatHandler.shutdown();
-		if (this.state != State.DISCONNECTING && statusCode != 4003 && statusCode != 4004 && statusCode != 4005 && statusCode != 4010 && (statusCode == 1001 ^ reason.equals("Shutdown"))) {
+		if (this.state != State.DISCONNECTING && statusCode != 4003 && statusCode != 4004 && statusCode != 4005 && statusCode != 4010 && (statusCode != 1001 || !reason.equals("Shutdown"))) {
 			this.state = State.RESUMING;
 			client.getDispatcher().dispatch(new DisconnectedEvent(DisconnectedEvent.Reason.ABNORMAL_CLOSE, shard));
 			client.reconnectManager.scheduleReconnect(this);


### PR DESCRIPTION
### Prerequisites
* [x] I have read and understood the [contribution guidelines](CONTRIBUTING.md)
* [x] This pull request follows the code style of the project
* [x] I have tested this feature thoroughly
  * [Proof of testing](https://gist.github.com/quanticc/f52174d007ae464c1d57a7617c4e4b4c)

**Issues Fixed:**
- Reconnect breaking because I fail at logic

### Changes Proposed in this Pull Request
* Properly catch the case of code 1001 + reason Shutdown and all other combos should perform the reconnect.

![chrome_2017-01-25_16-35-19](https://cloud.githubusercontent.com/assets/1908830/22306001/55025bc4-e31c-11e6-915f-e0b872d593c4.png)

