### PR TITLE
Fix reconnects

### DIFF
--- a/src/main/java/sx/blah/discord/api/internal/DiscordWS.java
+++ b/src/main/java/sx/blah/discord/api/internal/DiscordWS.java
@@ -124,7 +124,7 @@ public class DiscordWS extends WebSocketAdapter {
 		hasReceivedReady = false;
 		heartbeatHandler.shutdown();
 		if (!(this.state == State.DISCONNECTING || statusCode == 4003 || statusCode == 4004 || statusCode == 4005 ||
-				statusCode == 4010) && !(statusCode == 1001 && reason.equals("Shutdown"))) {
+				statusCode == 4010) && !(statusCode == 1001 && reason != null && reason.equals("Shutdown"))) {
 			this.state = State.RESUMING;
 			client.getDispatcher().dispatch(new DisconnectedEvent(DisconnectedEvent.Reason.ABNORMAL_CLOSE, shard));
 			client.reconnectManager.scheduleReconnect(this);


### PR DESCRIPTION
While still fulfilling #207's original idea. Partially reverts de7db30 that *might* break reconnects.

Jetty WS manages the provided HttpClient with its own lifecycle system `addBean`, `unmanage`, etc. therefore subject to release upon the ``wsClient.close()`` call. This PR also moves the call towards the end of the connect() method.

Trace of the 1001 + null happenings on all commits on dev between #205 and this PR:
https://gist.github.com/quanticc/70ece0c96cf6db7741b68543cd346cb2

NPE log only visible when using ``Discord4J.enableJettyLogging()`` and proper jetty logger level. Adding a null check to `DiscordWS#onWebSocketClose` fixes it.

### Prerequisites
* [x] I have read and understood the [contribution guidelines](CONTRIBUTING.md)
* [x] This pull request follows the code style of the project
* [x] I have tested this feature thoroughly

### Error codes covered
* [x] [1006 + WebSocket Read EOF](https://gist.github.com/quanticc/a119060fbfd00240d62e6b7f91cb7b79)
* [x] [1001 + CloudFlare WebSocket proxy restarting](https://gist.github.com/quanticc/e6f68de194dc4290e17cf039dfbc6e83)
* [x] 1001 + null (that caused NPE affecting #205, #207, 6ae6472ceae4df2eb04ae3cc9e3c23ac9b3ebe9f and beyond) [Trace](https://gist.github.com/quanticc/70ece0c96cf6db7741b68543cd346cb2)

### Changes Proposed in this Pull Request
* Revert a change in #207 - Purpose of that PR still holds
* Patch a NPE with #205 to handle the 1001 code + null reason
