### PR TITLE
Hide tokens from websocket trace log level

### DIFF
--- a/src/main/java/sx/blah/discord/api/internal/DiscordWS.java
+++ b/src/main/java/sx/blah/discord/api/internal/DiscordWS.java
@@ -210,7 +210,7 @@ public class DiscordWS extends WebSocketAdapter {
 
 	public void send(String message) {
 		if (getSession() != null && getSession().isOpen()) {
-			Discord4J.LOGGER.trace(LogMarkers.WEBSOCKET_TRAFFIC, "Sending: " + message);
+			Discord4J.LOGGER.trace(LogMarkers.WEBSOCKET_TRAFFIC, "Sending: " + message.replaceAll("^(.*\"token\":\"Bot )(.{59})(\".*)$", "$1******$3"));
 			getSession().getRemote().sendStringByFuture(message);
 		} else {
 			Discord4J.LOGGER.warn(LogMarkers.WEBSOCKET, "Attempt to send message on closed session: {}", message);


### PR DESCRIPTION
### Prerequisites
* [x] I have read and understood the [contribution guidelines](CONTRIBUTING.md)
* [x] This pull request follows the code style of the project
* [x] I have tested this feature thoroughly

```
2017-02-25 14:08:57.221  INFO 8476 --- [t@1384584502-59] sx.blah.discord.Discord4J                : Websocket Connected.
2017-02-25 14:08:57.236 TRACE 8476 --- [t@1384584502-59] sx.blah.discord.Discord4J                : Received: {"t":null,"s":null,"op":10,"d":{"heartbeat_interval":41250,"_trace":["discord-gateway-prd-1-10"]}}
2017-02-25 14:08:57.238 TRACE 8476 --- [t@1384584502-59] sx.blah.discord.Discord4J                : Shard 0 _trace: ["discord-gateway-prd-1-10"]
2017-02-25 14:08:57.258 TRACE 8476 --- [t@1384584502-59] sx.blah.discord.Discord4J                : Sending: {"t":null,"s":null,"op":2,"d":{"token":"Bot ******","properties":{"$os":"Windows 10","$browser":"Discord4J","$device":"Discord4J","$referrer":"","$referring_domain":""},"compress":true,"large_threshold":250,"shard":[0,1]}}
2017-02-25 14:08:57.258 TRACE 8476 --- [p-Alive Handler] sx.blah.discord.Discord4J                : Sending heartbeat on shard 0
2017-02-25 14:08:57.259 TRACE 8476 --- [p-Alive Handler] sx.blah.discord.Discord4J                : Sending: {"t":null,"s":null,"op":1,"d":0}
2017-02-25 14:08:57.603 TRACE 8476 --- [t@1384584502-63] sx.blah.discord.Discord4J                : Received: {"t":"READY","s":1,"op":0,"d":{"v":5,"..........
```

**Issues Fixed:** (none)

### Changes Proposed in this Pull Request
* Replace token appearing on outgoing websocket traffic log with `******`
