### PR TITLE
Display presence details only when they are present

### DIFF
--- a/src/main/java/sx/blah/discord/handle/impl/obj/PresenceImpl.java
+++ b/src/main/java/sx/blah/discord/handle/impl/obj/PresenceImpl.java
@@ -54,7 +54,7 @@ public class PresenceImpl implements IPresence {
 
 	@Override
 	public String toString() {
-		return status + " - playing " + getPlayingText().orElse(null) + " with streaming URL " +
-				getStreamingUrl().orElse(null);
+		return status + (getPlayingText().isPresent() ? " - playing " + getPlayingText().get() : "") +
+				(getStreamingUrl().isPresent() ? " with streaming URL " + getStreamingUrl().get() : "");
 	}
 }


### PR DESCRIPTION
### Prerequisites
* [x] I have read and understood the [contribution guidelines](CONTRIBUTING.md)
* [x] This pull request follows the code style of the project
* [x] I have tested this feature thoroughly

```
2017-02-25 14:29:41.483 DEBUG 10912 --- [nt@474017583-50] sx.blah.discord.Discord4J                : User "quantic" changed presence to DND
2017-02-25 14:29:49.058 DEBUG 10912 --- [nt@474017583-59] sx.blah.discord.Discord4J                : User "quantic" changed presence to ONLINE
2017-02-25 14:30:02.205 DEBUG 10912 --- [nt@474017583-63] sx.blah.discord.Discord4J                : User "quantic" changed presence to ONLINE - playing Guild Wars 2
2017-02-25 14:30:27.126 DEBUG 10912 --- [nt@474017583-61] sx.blah.discord.Discord4J                : User "quantic" changed presence to ONLINE
2017-02-25 14:51:06.514 DEBUG 10912 --- [nt@474017583-85] sx.blah.discord.Discord4J                : User "quantic" changed presence to STREAMING - playing  with streaming URL https://www.twitch.tv/quantictf2
2017-02-25 14:53:08.646 DEBUG 10912 --- [nt@474017583-88] sx.blah.discord.Discord4J                : User "quantic" changed presence to STREAMING - playing test with streaming URL https://www.twitch.tv/quantictf2
2017-02-25 14:53:46.430 DEBUG 10912 --- [nt@474017583-89] sx.blah.discord.Discord4J                : User "quantic" changed presence to ONLINE
```

**Issues Fixed:** (none)

### Changes Proposed in this Pull Request
* Logs only display a presence field if it's present.
