### PR TITLE
Handle message update events with partial contents

### DIFF
--- a/src/main/java/sx/blah/discord/api/internal/DispatchHandler.java
+++ b/src/main/java/sx/blah/discord/api/internal/DispatchHandler.java
@@ -307,11 +307,11 @@ class DispatchHandler {
 		Message toUpdate = (Message) channel.getMessageByID(id);
 		IMessage oldMessage = toUpdate != null ? toUpdate.copy() : null;
 
-		toUpdate = (Message) DiscordUtils.getMessageFromJSON(channel, json);
+		toUpdate = (Message) DiscordUtils.getUpdatedMessageFromJSON(toUpdate, json);
 
-		if (oldMessage != null && oldMessage.isPinned() && !json.pinned) {
+		if (oldMessage != null && json.pinned != null && oldMessage.isPinned() && !json.pinned) {
 			client.dispatcher.dispatch(new MessageUnpinEvent(toUpdate));
-		} else if (oldMessage != null && !oldMessage.isPinned() && json.pinned) {
+		} else if (oldMessage != null && json.pinned != null && !oldMessage.isPinned() && json.pinned) {
 			client.dispatcher.dispatch(new MessagePinEvent(toUpdate));
 		} else if (oldMessage != null && oldMessage.getEmbedded().size() < toUpdate.getEmbedded().size()) {
 			client.dispatcher.dispatch(new MessageEmbedEvent(toUpdate, oldMessage.getEmbedded()));

--- a/src/main/java/sx/blah/discord/api/internal/json/objects/MessageObject.java
+++ b/src/main/java/sx/blah/discord/api/internal/json/objects/MessageObject.java
@@ -63,7 +63,7 @@ public class MessageObject {
 	/**
 	 * Whether the message is pinned.
 	 */
-	public boolean pinned;
+	public Boolean pinned;
 	/**
 	 * The reactions on the message.
 	 */


### PR DESCRIPTION
### Prerequisites
* [x] I have read and understood the [contribution guidelines](CONTRIBUTING.md)
* [x] This pull request follows the code style of the project
* [x] I have tested this feature thoroughly
  * [Proof of testing - Client](http://imgur.com/a/ICQZT)
  * [Proof of testing - Bot trace](https://gist.github.com/quanticc/f5f42c97501bcb136035cf9d7febb2b1)

**Issues Fixed:**
* Message update events with a partial message payload would result in incorrectly sent unpin events, or deletion of some of the cached fields. Reported by UnderMybrella#4076

### Changes Proposed in this Pull Request
* Use Boolean instead of boolean for the pinned field in MessageObject, so that it could be null instead of false when updating messages from an incomplete payload.
* Add a getUpdatedMessageFromJSON to DiscordUtils and use it to handle message update events.
* Wrap json.pinned with Boolean.TRUE.equals to ensure we never pass null to those fields, which would cause an NPE.


