### PR TITLE
Fixed audio decryption

### DIFF
--- a/src/main/java/sx/blah/discord/api/internal/DiscordClientImpl.java
+++ b/src/main/java/sx/blah/discord/api/internal/DiscordClientImpl.java
@@ -15,18 +15,9 @@ import sx.blah.discord.handle.impl.events.ShardReadyEvent;
 import sx.blah.discord.handle.impl.obj.User;
 import sx.blah.discord.handle.obj.*;
 import sx.blah.discord.modules.ModuleLoader;
-import sx.blah.discord.util.DiscordException;
-import sx.blah.discord.util.Image;
-import sx.blah.discord.util.LogMarkers;
-import sx.blah.discord.util.RateLimitException;
-import sx.blah.discord.util.RequestBuilder;
+import sx.blah.discord.util.*;
 
-import java.util.Arrays;
-import java.util.List;
-import java.util.Map;
-import java.util.Timer;
-import java.util.TimerTask;
-import java.util.concurrent.ConcurrentHashMap;
+import java.util.*;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.stream.Collectors;
 
@@ -419,7 +410,7 @@ public final class DiscordClientImpl implements IDiscordClient {
 
 	@Override
 	public List<IVoiceChannel> getConnectedVoiceChannels() {
-		return getOurUser().getVoiceStates().values().stream().map(IVoiceState::getChannel).collect(Collectors.toList());
+		return getOurUser().getVoiceStates().values().stream().map(IVoiceState::getChannel).filter(Objects::nonNull).collect(Collectors.toList());
 	}
 
 	@Override

--- a/src/main/java/sx/blah/discord/api/internal/OpusPacket.java
+++ b/src/main/java/sx/blah/discord/api/internal/OpusPacket.java
@@ -16,7 +16,7 @@ public class OpusPacket {
 
 	OpusPacket(DatagramPacket udpPacket) {
 		this.header = new RTPHeader(Arrays.copyOf(udpPacket.getData(), RTPHeader.LENGTH));
-		this.audio = Arrays.copyOfRange(udpPacket.getData(), RTPHeader.LENGTH, udpPacket.getData().length);
+		this.audio = Arrays.copyOfRange(udpPacket.getData(), RTPHeader.LENGTH, udpPacket.getLength());
 		this.isEncrypted = true;
 	}
 
@@ -42,12 +42,15 @@ public class OpusPacket {
 
 		//audio = new TweetNaclFast.SecretBox(secret).open(audio);
 		audio = TweetNaCl.secretbox_open(audio, getNonce(), secret);
-		System.out.println(Arrays.toString(audio));
 		isEncrypted = false;
 	}
 
 	byte[] asByteArray() {
 		return ArrayUtils.addAll(header.asByteArray(), audio);
+	}
+
+	byte[] getAudio() {
+		return ArrayUtils.clone(audio);
 	}
 
 	private byte[] getNonce() {

--- a/src/main/java/sx/blah/discord/api/internal/UDPVoiceSocket.java
+++ b/src/main/java/sx/blah/discord/api/internal/UDPVoiceSocket.java
@@ -1,11 +1,11 @@
 package sx.blah.discord.api.internal;
 
 import org.apache.commons.lang3.tuple.Pair;
-import org.peergos.crypto.TweetNaCl;
 import sx.blah.discord.Discord4J;
 import sx.blah.discord.api.internal.json.requests.voice.SelectProtocolRequest;
 import sx.blah.discord.api.internal.json.requests.voice.VoiceSpeakingRequest;
 import sx.blah.discord.handle.audio.impl.AudioManager;
+import sx.blah.discord.handle.obj.IUser;
 import sx.blah.discord.util.LogMarkers;
 
 import java.io.IOException;
@@ -62,47 +62,13 @@ public class UDPVoiceSocket {
 				DatagramPacket udpPacket = new DatagramPacket(new byte[1920], 1920);
 				udpSocket.receive(udpPacket);
 
-				/*
-				System.out.println(Arrays.toString(udpPacket.getData()));
-
 				OpusPacket opusPacket = new OpusPacket(udpPacket);
 				opusPacket.decrypt(secret);
 
-				System.out.println(Arrays.toString(opusPacket.asByteArray()));
-
 				IUser userSpeaking = voiceWS.users.get(opusPacket.header.ssrc);
 				if (userSpeaking != null) {
-					((AudioManager) voiceWS.getGuild().getAudioManager()).receiveAudio(opusPacket.asByteArray(), userSpeaking);
+					((AudioManager) voiceWS.getGuild().getAudioManager()).receiveAudio(opusPacket.getAudio(), userSpeaking);
 				}
-				*/
-
-				System.out.println(Arrays.toString(secret));
-
-				byte[] data = udpPacket.getData();
-				byte[] nonce = new byte[24];
-				byte[] audio = new byte[data.length - 12];
-
-				System.arraycopy(data, 0, nonce, 0, 12);
-				System.arraycopy(data, 12, audio, 0, audio.length);
-
-				//byte[] decrypted = new TweetNaclFast.SecretBox(secret).open(audio, nonce);
-				byte[] decrypted = TweetNaCl.secretbox_open(audio, nonce, secret);
-				System.out.println(Arrays.toString(decrypted));
-
-				/*
-				byte[] ary = udpPacket.getData();
-				byte[] header = Arrays.copyOfRange(ary, 0, 12);
-				byte[] nonce = ArrayUtils.addAll(header, new byte[12]);
-				byte[] audio = new byte[ary.length - 12];
-				TweetNaCl.secretbox_open(audio, nonce, secret);
-				*/
-
-				/*
-				System.out.println(Arrays.toString(udpPacket.getData()));
-				System.out.println(Arrays.toString(Arrays.copyOf(udpPacket.getData(), OpusPacket.RTPHeader.LENGTH)));
-				System.out.println(Arrays.toString(Arrays.copyOfRange(udpPacket.getData(), OpusPacket.RTPHeader.LENGTH, udpPacket.getData().length)));
-				*/
-
 			}
 		} catch (Exception e) {
 			Discord4J.LOGGER.error(LogMarkers.VOICE_WEBSOCKET, "Discord4J Internal Exception", e);

--- a/src/main/java/sx/blah/discord/handle/impl/obj/VoiceChannel.java
+++ b/src/main/java/sx/blah/discord/handle/impl/obj/VoiceChannel.java
@@ -239,7 +239,7 @@ public class VoiceChannel extends Channel implements IVoiceChannel {
 
 	@Override
 	public List<IUser> getConnectedUsers() {
-		return guild.getUsers().stream().filter(u -> u.getVoiceStateForGuild(guild).getChannel().equals(this)).collect(Collectors.toList());
+		return guild.getUsers().stream().filter(u -> u.getVoiceStateForGuild(guild).getChannel() != null && u.getVoiceStateForGuild(guild).getChannel().equals(this)).collect(Collectors.toList());
 	}
 
 	@Override


### PR DESCRIPTION
### Prerequisites
* [x] I have read and understood the [contribution guidelines](CONTRIBUTING.md)
* [x] This pull request follows the code style of the project
* [x] I have tested this feature thoroughly
  * [Audio's a bit difficult, but here's 5 seconds of audio data](https://gist.github.com/UnderMybrella/a7a8a45fe8f0545cd7ef860f513162db)

**Issues Fixed:** 
* Audio decryption
* NullPointerExceptions in IVoiceChannel#getConnectedUsers (And therefore IVoiceChannel#getUsersHere), and NPEs while iterating over IDiscordClient#getConnectedVoiceChannels

### Changes Proposed in this Pull Request
* Changed OpusPacket to use the DatagramPacket's length when constructing with a packet, rather than the packet data's length
* Added OpusPacket#getAudio, which returns a clone of the audio data in the packet
* Removed debug code from UDPVoiceSocket's receiveRunnable, replacing with the (existing) code to initialise an OpusPacket from a DatagramPacket
* Changed the receiveAudio call in UDPVoiceSocket's receiveRunnable, to only supply the audio data, rather than the entire packet (which would include the header information)
* Check if the channel in a voice state is null before checking if the channel is equal to this one when running IVoiceChannel#getConnectedUsers
* Eliminate null channels when IDiscordClient#getConnectedVoiceChannels is called

