### PR TITLE
Fixed user/guild/channel data getting reset

### DIFF
--- a/src/main/java/sx/blah/discord/api/internal/DiscordUtils.java
+++ b/src/main/java/sx/blah/discord/api/internal/DiscordUtils.java
@@ -1,6 +1,7 @@
 package sx.blah.discord.api.internal;
 
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.PropertyAccessor;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.DeserializationFeature;
@@ -69,6 +70,7 @@ public class DiscordUtils {
 	 */
 	public static final ObjectMapper MAPPER_NO_NULLS = new ObjectMapper()
 			.registerModule(new AfterburnerModule())
+			.setSerializationInclusion(JsonInclude.Include.NON_NULL)
 			.enable(SerializationFeature.USE_EQUALITY_FOR_OBJECT_ID)
 			.disable(SerializationFeature.WRITE_NULL_MAP_VALUES)
 			.enable(DeserializationFeature.USE_JAVA_ARRAY_FOR_JSON_ARRAY)

--- a/src/main/java/sx/blah/discord/handle/impl/obj/Guild.java
+++ b/src/main/java/sx/blah/discord/handle/impl/obj/Guild.java
@@ -1,5 +1,7 @@
 package sx.blah.discord.handle.impl.obj;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import org.apache.http.entity.StringEntity;
 import sx.blah.discord.Discord4J;
 import sx.blah.discord.api.IDiscordClient;
 import sx.blah.discord.api.IShard;
@@ -20,6 +22,7 @@ import sx.blah.discord.handle.impl.events.WebhookUpdateEvent;
 import sx.blah.discord.handle.obj.*;
 import sx.blah.discord.util.*;
 
+import java.io.UnsupportedEncodingException;
 import java.time.LocalDateTime;
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
@@ -415,8 +418,12 @@ public class Guild implements IGuild {
 	public void editUserRoles(IUser user, IRole[] roles) throws DiscordException, RateLimitException, MissingPermissionsException {
 		DiscordUtils.checkPermissions(client, this, Arrays.asList(roles), EnumSet.of(Permissions.MANAGE_ROLES));
 
-		((DiscordClientImpl) client).REQUESTS.PATCH.makeRequest(
-				DiscordEndpoints.GUILDS+id+"/members/"+user.getID(), new MemberEditRequest(roles));
+		try {
+			((DiscordClientImpl) client).REQUESTS.PATCH.makeRequest(
+					DiscordEndpoints.GUILDS+id+"/members/"+user.getID(), new StringEntity(DiscordUtils.MAPPER_NO_NULLS.writeValueAsString(new MemberEditRequest(roles))));
+		} catch (UnsupportedEncodingException | JsonProcessingException e) {
+			Discord4J.LOGGER.error(LogMarkers.HANDLE, "Discord4J Internal Exception", e);
+		}
 
 	}
 
@@ -424,16 +431,24 @@ public class Guild implements IGuild {
 	public void setDeafenUser(IUser user, boolean deafen) throws DiscordException, RateLimitException, MissingPermissionsException {
 		DiscordUtils.checkPermissions(client, this, user.getRolesForGuild(this), EnumSet.of(Permissions.VOICE_DEAFEN_MEMBERS));
 
-		((DiscordClientImpl) client).REQUESTS.PATCH.makeRequest(
-				DiscordEndpoints.GUILDS+id+"/members/"+user.getID(), new MemberEditRequest(deafen));
+		try {
+			((DiscordClientImpl) client).REQUESTS.PATCH.makeRequest(
+					DiscordEndpoints.GUILDS+id+"/members/"+user.getID(), new StringEntity(DiscordUtils.MAPPER_NO_NULLS.writeValueAsString(new MemberEditRequest(deafen))));
+		} catch (UnsupportedEncodingException | JsonProcessingException e) {
+			Discord4J.LOGGER.error(LogMarkers.HANDLE, "Discord4J Internal Exception", e);
+		}
 	}
 
 	@Override
 	public void setMuteUser(IUser user, boolean mute) throws DiscordException, RateLimitException, MissingPermissionsException {
 		DiscordUtils.checkPermissions(client, this, user.getRolesForGuild(this), EnumSet.of(Permissions.VOICE_MUTE_MEMBERS));
 
-		((DiscordClientImpl) client).REQUESTS.PATCH.makeRequest(
-				DiscordEndpoints.GUILDS+id+"/members/"+user.getID(), new MemberEditRequest(mute, true));
+		try {
+			((DiscordClientImpl) client).REQUESTS.PATCH.makeRequest(
+					DiscordEndpoints.GUILDS+id+"/members/"+user.getID(), new StringEntity(DiscordUtils.MAPPER_NO_NULLS.writeValueAsString(new MemberEditRequest(mute, true))));
+		} catch (UnsupportedEncodingException | JsonProcessingException e) {
+			Discord4J.LOGGER.error(LogMarkers.HANDLE, "Discord4J Internal Exception", e);
+		}
 	}
 
 	@Override
@@ -445,9 +460,13 @@ public class Guild implements IGuild {
 			DiscordUtils.checkPermissions(client, this, user.getRolesForGuild(this), EnumSet.of(Permissions.MANAGE_NICKNAMES));
 		}
 
-		((DiscordClientImpl) client).REQUESTS.PATCH.makeRequest(
-				DiscordEndpoints.GUILDS+id+"/members/"+(isSelf ? "@me/nick" : user.getID()),
-				new MemberEditRequest(nick == null ? "" : nick, true));
+		try {
+			((DiscordClientImpl) client).REQUESTS.PATCH.makeRequest(
+					DiscordEndpoints.GUILDS+id+"/members/"+(isSelf ? "@me/nick" : user.getID()),
+					new StringEntity(DiscordUtils.MAPPER_NO_NULLS.writeValueAsString(new MemberEditRequest(nick == null ? "" : nick, true))));
+		} catch (UnsupportedEncodingException | JsonProcessingException e) {
+			Discord4J.LOGGER.error(LogMarkers.HANDLE, "Discord4J Internal Exception", e);
+		}
 	}
 
 	@Override

--- a/src/main/java/sx/blah/discord/handle/impl/obj/User.java
+++ b/src/main/java/sx/blah/discord/handle/impl/obj/User.java
@@ -1,5 +1,8 @@
 package sx.blah.discord.handle.impl.obj;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import org.apache.http.entity.StringEntity;
+import sx.blah.discord.Discord4J;
 import sx.blah.discord.api.IDiscordClient;
 import sx.blah.discord.api.IShard;
 import sx.blah.discord.api.internal.DiscordClientImpl;
@@ -8,9 +11,11 @@ import sx.blah.discord.api.internal.DiscordUtils;
 import sx.blah.discord.api.internal.json.requests.MemberEditRequest;
 import sx.blah.discord.handle.obj.*;
 import sx.blah.discord.util.DiscordException;
+import sx.blah.discord.util.LogMarkers;
 import sx.blah.discord.util.MissingPermissionsException;
 import sx.blah.discord.util.RateLimitException;
 
+import java.io.UnsupportedEncodingException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.EnumSet;
@@ -286,9 +291,13 @@ public class User implements IUser {
 					EnumSet.of(Permissions.VOICE_MOVE_MEMBERS));
 		}
 
-		((DiscordClientImpl) client).REQUESTS.PATCH.makeRequest(
-				DiscordEndpoints.GUILDS + newChannel.getGuild().getID() + "/members/" + id,
-				new MemberEditRequest(newChannel.getID()));
+		try {
+			((DiscordClientImpl) client).REQUESTS.PATCH.makeRequest(
+					DiscordEndpoints.GUILDS + newChannel.getGuild().getID() + "/members/" + id,
+					new StringEntity(DiscordUtils.MAPPER_NO_NULLS.writeValueAsString(new MemberEditRequest(newChannel.getID()))));
+		} catch (UnsupportedEncodingException | JsonProcessingException e) {
+			Discord4J.LOGGER.error(LogMarkers.HANDLE, "Discord4J Internal Exception", e);
+		}
 	}
 
 	@Override


### PR DESCRIPTION
### Prerequisites
* [X] I have read and understood the [contribution guidelines](CONTRIBUTING.md)
* [X] This pull request follows the code style of the project
* [X] I have tested this feature thoroughly
 
`System.out.println(DiscordUtils.MAPPER_NO_NULLS.writeValueAsString(new MemberEditRequest("Test Nick Please Ignore", true)));`

`Before {"roles":null,"nick":"Test Nick Please Ignore","mute":null,"deaf":null,"channel_id":null}`

`After {"nick":"Test Nick Please Ignore"}`

**Issues Fixed:** 
Fixed DiscordUtils.MAPPER_NO_NULLS not ignoring nulls
Fixed methods not using DiscordUtils.MAPPER_NO_NULLS

