### PR TITLE
Add a default, no-params ClientBuilder#withRecommendedShardCount method

### DIFF
--- a/src/main/java/sx/blah/discord/api/ClientBuilder.java
+++ b/src/main/java/sx/blah/discord/api/ClientBuilder.java
@@ -108,16 +108,25 @@ public class ClientBuilder {
 		this.shardCount = shardCount;
 		return this;
 	}
-
+	
+	/**
+	 * Sets whether the bot should use Discord's recommended number of shards on login.
+	 *
+	 * @param useRecommended If the bot is to use the recommended number of shards.
+	 * @return The instance of the builder.
+	 */
+	public ClientBuilder withRecommendedShardCount(boolean useRecommended) {
+		this.withRecomendedShardCount = useRecommended;
+		return this;
+	}
+	
 	/**
 	 * Sets the bot to use Discord's recommended number of shards on login.
 	 *
-	 * @param useRecommended If the bot is to use the recommended number of shards
 	 * @return The instance of the builder.
 	 */
-	public ClientBuilder withRecommendedShardCount(boolean useRecommended){
-		this.withRecomendedShardCount = useRecommended;
-		return this;
+	public ClientBuilder withRecommendedShardCount() {
+		return withRecommendedShardCount(true);
 	}
 
 	/**


### PR DESCRIPTION
### Prerequisites
* [x] I have read and understood the [contribution guidelines](CONTRIBUTING.md)
* [x] This pull request follows the code style of the project
* [ ] I have tested this feature thoroughly

### Changes Proposed in this Pull Request
* Added a default, no-params `withRecommendedShardCount()` method for `ClientBuilder` which calls `withRecommendedShardCount(true)` to use Discord's recommended shard count.

