### PR TITLE
Fix permissions not returning properly for guild owner

### DIFF
--- a/src/main/java/sx/blah/discord/handle/impl/obj/User.java
+++ b/src/main/java/sx/blah/discord/handle/impl/obj/User.java
@@ -212,6 +212,8 @@ public class User implements IUser {
 
 	@Override
 	public EnumSet<Permissions> getPermissionsForGuild(IGuild guild){
+		if (guild.getOwner().equals(this))
+			return EnumSet.allOf(Permissions.class);
 		EnumSet<Permissions> permissions = EnumSet.noneOf(Permissions.class);
 		getRolesForGuild(guild).forEach(role -> permissions.addAll(role.getPermissions()));
 		return permissions;


### PR DESCRIPTION
### Prerequisites
* [x] I have read and understood the [contribution guidelines](CONTRIBUTING.md)
* [x] This pull request follows the code style of the project
* [x] I have tested this feature thoroughly
  * [Proof of testing](http://image.prntscr.com/image/75a5d3a7f2d248c585fd7f4d192ef36e.png)
  * [I blame brella if this somehow doesn't compile](http://image.prntscr.com/image/6aa2db6ad0cc4001bc3b4a2935d61bff.png)

**Issues Fixed:** If you do `getPermissionsForGuild` on the owner, it grabs the Permissions from their roles, while this works as intended it should return all permissions as the Guild owner can do it all.

### Changes Proposed in this Pull Request
* Return an EnumSet of all Permissions when calling the Guild owner

...


