### PR TITLE
Fixed IReaction getCount() and getUsers() from returning incorrect va…

### DIFF
--- a/src/main/java/sx/blah/discord/api/internal/DispatchHandler.java
+++ b/src/main/java/sx/blah/discord/api/internal/DispatchHandler.java
@@ -730,7 +730,7 @@ class DispatchHandler {
 					message.getReactions().add(reaction);
 				} else {
 					reaction.getCachedUsers().add(user);
-					reaction.setCount(reaction.getCount() + 1);
+					reaction.setCount(reaction.getCount());
 				}
 
 				reaction.setMessage(message);


### PR DESCRIPTION
### Prerequisites
* [x] I have read and understood the [contribution guidelines](CONTRIBUTING.md)
* [x] This pull request follows the code style of the project
* [x] I have tested this feature thoroughly
  * [Proof of testing]

#### Code for testing purposes

    ```Kotlin
    .registerListener(object : IListener<ReactionAddEvent> {
       override fun handle(event: ReactionAddEvent) {
          System.out.println(event.reaction.count)
           System.out.println(event.reaction.users)
    })
    ```
#### Info:
A single message, with 1 reaction Emoji and 2 users that have reacted to it

#### Previous output:
3
[<@!90654002894639104>, <@!90654002894639104>, <@!204241990509002752>, <@!204241990509002752>]

#### Output After Changes:
2
[<@!90654002894639104>, <@!204241990509002752>]

**Issues Fixed:** [The issues fixed by this pull request]
* IReaction#getCount() returning +1 more than it should
* IReaction#getUsers() returning duplicate users

### Changes Proposed in this Pull Request
* Remove " + 1" on line 733 in DispatchHandler.java

...


