### PR TITLE
Go ahead of string ids in favor of long keys

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -154,6 +154,18 @@
 			<version>3.2.0</version>
 		</dependency>
 
+		<dependency>
+			<groupId>com.koloboke</groupId>
+			<artifactId>koloboke-compile</artifactId>
+			<version>0.5.1</version>
+			<scope>provided</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>com.koloboke</groupId>
+			<artifactId>koloboke-impl-common-jdk8</artifactId>
+			<version>1.0.0</version>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/src/main/java/sx/blah/discord/api/IDiscordClient.java
+++ b/src/main/java/sx/blah/discord/api/IDiscordClient.java
@@ -218,8 +218,21 @@ public interface IDiscordClient {
 	 *
 	 * @param channelID The id of the desired channel.
 	 * @return The {@link Channel} object with the provided id.
+	 * @deprecated Use {@link #getChannelByID(long)} instead
 	 */
-	IChannel getChannelByID(String channelID);
+	@Deprecated
+	default IChannel getChannelByID(String channelID) {
+		if (channelID == null) return null;
+		return getChannelByID(Long.parseUnsignedLong(channelID));
+	}
+
+	/**
+	 * Gets a channel by its unique id.
+	 *
+	 * @param channelID The id of the desired channel.
+	 * @return The {@link Channel} object with the provided id.
+	 */
+	IChannel getChannelByID(long channelID);
 
 	/**
 	 * Gets a set of all voice channels visible to the bot user.
@@ -233,8 +246,21 @@ public interface IDiscordClient {
 	 *
 	 * @param id The voice channel id.
 	 * @return The voice channel (or null if not found).
+	 * @deprecated Use {@link #getVoiceChannelByID(long)} instead
 	 */
-	IVoiceChannel getVoiceChannelByID(String id);
+	@Deprecated
+	default IVoiceChannel getVoiceChannelByID(String id) {
+		if (id == null) return null;
+		return getVoiceChannelByID(Long.parseUnsignedLong(id));
+	}
+
+	/**
+	 * Gets a voice channel from a given id.
+	 *
+	 * @param id The voice channel id.
+	 * @return The voice channel (or null if not found).
+	 */
+	IVoiceChannel getVoiceChannelByID(long id);
 
 	/**
 	 * Gets all the guilds the user the api represents is connected to.
@@ -248,8 +274,21 @@ public interface IDiscordClient {
 	 *
 	 * @param guildID The id of the desired guild.
 	 * @return The {@link Guild} object with the provided id.
+	 * @deprecated Use {@link #getGuildByID(long)} instead
 	 */
-	IGuild getGuildByID(String guildID);
+	@Deprecated
+	default IGuild getGuildByID(String guildID) {
+		if (guildID == null) return null;
+		return getGuildByID(Long.parseUnsignedLong(guildID));
+	}
+
+	/**
+	 * Gets a guild by its unique id.
+	 *
+	 * @param guildID The id of the desired guild.
+	 * @return The {@link Guild} object with the provided id.
+	 */
+	IGuild getGuildByID(long guildID);
 
 	/**
 	 * Gets a set of all users visible to the bot user.
@@ -265,8 +304,23 @@ public interface IDiscordClient {
 	 * @return The {@link User} object with the provided id.
 	 *
 	 * @see #fetchUser(String)
+	 * @deprecated Use {@link #getUserByID(long)}
 	 */
-	IUser getUserByID(String userID);
+	@Deprecated
+	default IUser getUserByID(String userID) {
+		if (userID == null) return null;
+		return getUserByID(Long.parseUnsignedLong(userID));
+	}
+
+	/**
+	 * Gets a cached user by its unique id.
+	 *
+	 * @param userID The id of the desired user.
+	 * @return The {@link User} object with the provided id.
+	 *
+	 * @see #fetchUser(long)
+	 */
+	IUser getUserByID(long userID);
 
 	/**
 	 * This attempts to retrieve a user by its id by first checking the api's internal cache, if the user is not found,
@@ -279,8 +333,27 @@ public interface IDiscordClient {
 	 * @throws RateLimitException
 	 *
 	 * @see #getUserByID(String)
+	 * @deprecated Use {@link #fetchUser(long)} instead
 	 */
-	IUser fetchUser(String id);
+	@Deprecated
+	default IUser fetchUser(String id) {
+		if (id == null) return null;
+		return fetchUser(Long.parseUnsignedLong(id));
+	}
+
+	/**
+	 * This attempts to retrieve a user by its id by first checking the api's internal cache, if the user is not found,
+	 * a REST request is performed.
+	 *
+	 * @param id The id of the user to find.
+	 * @return Ths user fetched, if found.
+	 *
+	 * @throws DiscordException
+	 * @throws RateLimitException
+	 *
+	 * @see #getUserByID(long)
+	 */
+	IUser fetchUser(long id);
 
 	/**
 	 * Gets a set of users by their name, case-sensitive.
@@ -311,8 +384,21 @@ public interface IDiscordClient {
 	 *
 	 * @param roleID The id of the desired role.
 	 * @return The {@link Role} object
+	 * @deprecated Use {@link #getRoleByID(long)} instead
 	 */
-	IRole getRoleByID(String roleID);
+	@Deprecated
+	default IRole getRoleByID(String roleID) {
+		if (roleID == null) return null;
+		return getRoleByID(Long.parseUnsignedLong(roleID));
+	}
+
+	/**
+	 * Gets a role by its unique id.
+	 *
+	 * @param roleID The id of the desired role.
+	 * @return The {@link Role} object
+	 */
+	IRole getRoleByID(long roleID);
 
 	/**
 	 * This gets all messages stored internally by the bot.
@@ -336,8 +422,23 @@ public interface IDiscordClient {
 	 *
 	 * @param messageID The message id of the message to find.
 	 * @return The message or null if not found.
+	 * @deprecated Use {@link #getMessageByID(long)} instead
 	 */
-	IMessage getMessageByID(String messageID);
+	@Deprecated
+	default IMessage getMessageByID(String messageID) {
+		if (messageID == null) return null;
+		return getMessageByID(Long.parseUnsignedLong(messageID));
+	}
+
+	/**
+	 * This attempts to search all guilds/private channels for a message.
+	 * <b>NOTE:</b> This only checks already cached messages, see {@link IChannel#getMessageByID(long)} if you want
+	 * to retrieve messages which aren't cached already.
+	 *
+	 * @param messageID The message id of the message to find.
+	 * @return The message or null if not found.
+	 */
+	IMessage getMessageByID(long messageID);
 
 	/**
 	 * Gets a {@link IPrivateChannel} for the provided recipient.

--- a/src/main/java/sx/blah/discord/api/IShard.java
+++ b/src/main/java/sx/blah/discord/api/IShard.java
@@ -191,8 +191,21 @@ public interface IShard {
 	 *
 	 * @param channelID The id of the desired channel.
 	 * @return The {@link Channel} object with the provided id.
+	 * @deprecated Use {@link #getChannelByID(long)} instead
 	 */
-	IChannel getChannelByID(String channelID);
+	@Deprecated
+	default IChannel getChannelByID(String channelID) {
+		if (channelID == null) return null;
+		return getChannelByID(Long.parseUnsignedLong(channelID));
+	}
+
+	/**
+	 * Gets a channel by its unique id.
+	 *
+	 * @param channelID The id of the desired channel.
+	 * @return The {@link Channel} object with the provided id.
+	 */
+	IChannel getChannelByID(long channelID);
 
 	/**
 	 * Gets a set of all voice channels visible to this shard.
@@ -213,8 +226,21 @@ public interface IShard {
 	 *
 	 * @param id The voice channel id.
 	 * @return The voice channel (or null if not found).
+	 * @deprecated Use {@link #getVoiceChannelByID(long)} instead
 	 */
-	IVoiceChannel getVoiceChannelByID(String id);
+	@Deprecated
+	default IVoiceChannel getVoiceChannelByID(String id) {
+		if (id == null) return null;
+		return getVoiceChannelByID(Long.parseUnsignedLong(id));
+	}
+
+	/**
+	 * Gets a voice channel from a given id.
+	 *
+	 * @param id The voice channel id.
+	 * @return The voice channel (or null if not found).
+	 */
+	IVoiceChannel getVoiceChannelByID(long id);
 
 	/**
 	 * Gets a set of all guilds visible to this shard.
@@ -228,8 +254,21 @@ public interface IShard {
 	 *
 	 * @param guildID The id of the desired guild.
 	 * @return The {@link Guild} object with the provided id.
+	 * @deprecated Use {@link #getGuildByID(long)} instead
 	 */
-	IGuild getGuildByID(String guildID);
+	@Deprecated
+	default IGuild getGuildByID(String guildID) {
+		if (guildID == null) return null;
+		return getGuildByID(Long.parseUnsignedLong(guildID));
+	}
+
+	/**
+	 * Gets a guild by its unique id.
+	 *
+	 * @param guildID The id of the desired guild.
+	 * @return The {@link Guild} object with the provided id.
+	 */
+	IGuild getGuildByID(long guildID);
 
 	/**
 	 * Gets a set of all users visible to this shard.
@@ -245,8 +284,23 @@ public interface IShard {
 	 * @return The {@link User} object with the provided id.
 	 *
 	 * @see #fetchUser(String)
+	 * @deprecated Use {@link #getUserByID(long)} instead
 	 */
-	IUser getUserByID(String userID);
+	@Deprecated
+	default IUser getUserByID(String userID) {
+		if (userID == null) return null;
+		return getUserByID(Long.parseUnsignedLong(userID));
+	}
+
+	/**
+	 * Gets a cached user by its unique id.
+	 *
+	 * @param userID The id of the desired user.
+	 * @return The {@link User} object with the provided id.
+	 *
+	 * @see #fetchUser(long)
+	 */
+	IUser getUserByID(long userID);
 
 	/**
 	 * This attempts to retrieve a user by its id by first checking the api's internal cache, if the user is not found,
@@ -259,8 +313,27 @@ public interface IShard {
 	 * @throws RateLimitException
 	 *
 	 * @see #getUserByID(String)
+	 * @deprecated Use {@link #fetchUser(long)} instead
 	 */
-	IUser fetchUser(String id);
+	@Deprecated
+	default IUser fetchUser(String id) {
+		if (id == null) return null;
+		return fetchUser(Long.parseUnsignedLong(id));
+	}
+
+	/**
+	 * This attempts to retrieve a user by its id by first checking the api's internal cache, if the user is not found,
+	 * a REST request is performed.
+	 *
+	 * @param id The id of the user to find.
+	 * @return Ths user fetched, if found.
+	 *
+	 * @throws DiscordException
+	 * @throws RateLimitException
+	 *
+	 * @see #getUserByID(long)
+	 */
+	IUser fetchUser(long id);
 
 	/**
 	 * Gets a set of all roles visible to this shard.
@@ -274,8 +347,21 @@ public interface IShard {
 	 *
 	 * @param roleID The id of the desired role.
 	 * @return The {@link Role} object
+	 * @deprecated Use {@link #getRoleByID(long)} instead
 	 */
-	IRole getRoleByID(String roleID);
+	@Deprecated
+	default IRole getRoleByID(String roleID) {
+		if (roleID == null) return null;
+		return getRoleByID(Long.parseUnsignedLong(roleID));
+	}
+
+	/**
+	 * Gets a role by its unique id.
+	 *
+	 * @param roleID The id of the desired role.
+	 * @return The {@link Role} object
+	 */
+	IRole getRoleByID(long roleID);
 
 	/**
 	 * This gets all messages stored in this shard's cache.
@@ -299,8 +385,23 @@ public interface IShard {
 	 *
 	 * @param messageID The message id of the message to find.
 	 * @return The message or null if not found.
+	 * @deprecated Use {@link #getMessageByID(long)} instead
 	 */
-	IMessage getMessageByID(String messageID);
+	@Deprecated
+	default IMessage getMessageByID(String messageID) {
+		if (messageID == null) return null;
+		return getMessageByID(Long.parseUnsignedLong(messageID));
+	}
+
+	/**
+	 * This attempts to search all guilds/private channels visible to this shard for a message.
+	 * <b>NOTE:</b> This only checks already cached messages, see {@link IChannel#getMessageByID(long)} if you want
+	 * to retrieve messages which aren't cached already.
+	 *
+	 * @param messageID The message id of the message to find.
+	 * @return The message or null if not found.
+	 */
+	IMessage getMessageByID(long messageID);
 
 	/**
 	 * Gets a {@link IPrivateChannel} for the provided recipient.

--- a/src/main/java/sx/blah/discord/api/internal/DiscordClientImpl.java
+++ b/src/main/java/sx/blah/discord/api/internal/DiscordClientImpl.java
@@ -258,7 +258,7 @@ public final class DiscordClientImpl implements IDiscordClient {
 		try {
 			UserObject owner = getApplicationInfo().owner;
 
-			IUser user = getUserByID(owner.id);
+			IUser user = getUserByID(Long.parseUnsignedLong(owner.id));
 			if (user == null)
 				user = DiscordUtils.getUserFromJSON(getShards().get(0), owner);
 
@@ -397,7 +397,7 @@ public final class DiscordClientImpl implements IDiscordClient {
 	}
 
 	@Override
-	public IGuild getGuildByID(String guildID) {
+	public IGuild getGuildByID(long guildID) {
 		for (IShard shard : shards) {
 			IGuild guild = shard.getGuildByID(guildID);
 			if (guild != null)
@@ -424,7 +424,7 @@ public final class DiscordClientImpl implements IDiscordClient {
 	}
 
 	@Override
-	public IChannel getChannelByID(String channelID) {
+	public IChannel getChannelByID(long channelID) {
 		for (IShard shard : shards) {
 			IChannel channel = shard.getChannelByID(channelID);
 			if (channel != null)
@@ -448,7 +448,7 @@ public final class DiscordClientImpl implements IDiscordClient {
 	}
 
 	@Override
-	public IVoiceChannel getVoiceChannelByID(String id) {
+	public IVoiceChannel getVoiceChannelByID(long id) {
 		for (IShard shard : shards) {
 			IVoiceChannel voiceChannel = shard.getVoiceChannelByID(id);
 			if (voiceChannel != null)
@@ -468,7 +468,7 @@ public final class DiscordClientImpl implements IDiscordClient {
 	}
 
 	@Override
-	public IUser getUserByID(String userID) {
+	public IUser getUserByID(long userID) {
 		for (IShard shard : shards) {
 			IUser user = shard.getUserByID(userID);
 			if (user != null)
@@ -479,9 +479,9 @@ public final class DiscordClientImpl implements IDiscordClient {
 	}
 
 	@Override
-	public IUser fetchUser(String id) {
+	public IUser fetchUser(long id) {
 		IUser cached = getUserByID(id);
-		return cached == null ? DiscordUtils.getUserFromJSON(shards.get(0), REQUESTS.GET.makeRequest(DiscordEndpoints.USERS + id, UserObject.class)) : cached;
+		return cached == null ? DiscordUtils.getUserFromJSON(shards.get(0), REQUESTS.GET.makeRequest(DiscordEndpoints.USERS + Long.toUnsignedString(id), UserObject.class)) : cached;
 	}
 
 	@Override
@@ -505,7 +505,7 @@ public final class DiscordClientImpl implements IDiscordClient {
 	}
 
 	@Override
-	public IRole getRoleByID(String roleID) {
+	public IRole getRoleByID(long roleID) {
 		for (IShard shard : shards) {
 			IRole role = shard.getRoleByID(roleID);
 			if (role != null)
@@ -532,7 +532,7 @@ public final class DiscordClientImpl implements IDiscordClient {
 	}
 
 	@Override
-	public IMessage getMessageByID(String messageID) {
+	public IMessage getMessageByID(long messageID) {
 		for (IShard shard : shards) {
 			IMessage message = shard.getMessageByID(messageID);
 			if (message != null)

--- a/src/main/java/sx/blah/discord/api/internal/DiscordUtils.java
+++ b/src/main/java/sx/blah/discord/api/internal/DiscordUtils.java
@@ -106,7 +106,7 @@ public class DiscordUtils {
 	/**
 	 * Used to determine age based on discord ids
 	 */
-	public static final BigInteger DISCORD_EPOCH = new BigInteger("1420070400000");
+	public static final long DISCORD_EPOCH = 1420070400000l;
 
 	/**
 	 * If the input matches the toString() result of IEmoji.
@@ -140,12 +140,12 @@ public class DiscordUtils {
 			return null;
 
 		User user;
-		if (shard != null && (user = (User) shard.getUserByID(response.id)) != null) {
+		if (shard != null && (user = (User) shard.getUserByID(Long.parseUnsignedLong(response.id))) != null) {
 			user.setAvatar(response.avatar);
 			user.setName(response.username);
 			user.setDiscriminator(response.discriminator);
 		} else {
-			user = new User(shard, response.username, response.id, response.discriminator, response.avatar,
+			user = new User(shard, response.username, Long.parseUnsignedLong(response.id), response.discriminator, response.avatar,
 					new PresenceImpl(Optional.empty(), Optional.empty(), StatusType.OFFLINE), response.bot);
 		}
 		return user;
@@ -168,11 +168,11 @@ public class DiscordUtils {
 	 * @param json The json response to use.
 	 * @return The list of mentioned users.
 	 */
-	public static List<String> getMentionsFromJSON(MessageObject json) {
-		List<String> mentions = new ArrayList<>();
+	public static List<Long> getMentionsFromJSON(MessageObject json) {
+		List<Long> mentions = new ArrayList<>();
 		if (json.mentions != null)
 			for (UserObject response : json.mentions)
-				mentions.add(response.id);
+				mentions.add(Long.parseUnsignedLong(response.id));
 
 		return mentions;
 	}
@@ -183,11 +183,11 @@ public class DiscordUtils {
 	 * @param json The json response to use.
 	 * @return The list of mentioned roles.
 	 */
-	public static List<String> getRoleMentionsFromJSON(MessageObject json) {
-		List<String> mentions = new ArrayList<>();
+	public static List<Long> getRoleMentionsFromJSON(MessageObject json) {
+		List<Long> mentions = new ArrayList<>();
 		if (json.mention_roles != null)
 			for (String role : json.mention_roles)
-				mentions.add(role);
+				mentions.add(Long.parseUnsignedLong(role));
 
 		return mentions;
 	}
@@ -202,7 +202,7 @@ public class DiscordUtils {
 		List<IMessage.Attachment> attachments = new ArrayList<>();
 		if (json.attachments != null)
 			for (MessageObject.AttachmentObject response : json.attachments) {
-				attachments.add(new IMessage.Attachment(response.filename, response.size, response.id, response.url));
+				attachments.add(new IMessage.Attachment(response.filename, response.size, Long.parseUnsignedLong(response.id), response.url));
 			}
 
 		return attachments;
@@ -237,11 +237,12 @@ public class DiscordUtils {
 	public static IGuild getGuildFromJSON(IShard shard, GuildObject json) {
 		Guild guild;
 
-		if ((guild = (Guild) shard.getGuildByID(json.id)) != null) {
+		long guildId = Long.parseUnsignedLong(json.id);
+		if ((guild = (Guild) shard.getGuildByID(guildId)) != null) {
 			guild.setIcon(json.icon);
 			guild.setName(json.name);
-			guild.setOwnerID(json.owner_id);
-			guild.setAFKChannel(json.afk_channel_id);
+			guild.setOwnerID(Long.parseUnsignedLong(json.owner_id));
+			guild.setAFKChannel(Long.parseUnsignedLong(json.afk_channel_id));
 			guild.setAfkTimeout(json.afk_timeout);
 			guild.setRegion(json.region);
 			guild.setVerificationLevel(json.verification_level);
@@ -256,14 +257,14 @@ public class DiscordUtils {
 
 			for (IUser user : guild.getUsers()) { //Removes all deprecated roles
 				for (IRole role : user.getRolesForGuild(guild)) {
-					if (guild.getRoleByID(role.getID()) == null) {
+					if (guild.getRoleByID(role.getLongID()) == null) {
 						user.getRolesForGuild(guild).remove(role);
 					}
 				}
 			}
 		} else {
-			guild = new Guild(shard, json.name, json.id, json.icon, json.owner_id, json.afk_channel_id,
-					json.afk_timeout, json.region, json.verification_level);
+			guild = new Guild(shard, json.name, guildId, json.icon, Long.parseUnsignedLong(json.owner_id),
+					Long.parseUnsignedLong(json.afk_channel_id), json.afk_timeout, json.region, json.verification_level);
 
 			if (json.roles != null)
 				for (RoleObject roleResponse : json.roles) {
@@ -280,7 +281,7 @@ public class DiscordUtils {
 
 			if (json.presences != null)
 				for (PresenceObject presence : json.presences) {
-					User user = (User) guild.getUserByID(presence.user.id);
+					User user = (User) guild.getUserByID(Long.parseUnsignedLong(presence.user.id));
 					if (user != null) {
 						user.setPresence(DiscordUtils.getPresenceFromJSON(presence));
 					}
@@ -298,10 +299,10 @@ public class DiscordUtils {
 
 			if (json.voice_states != null) {
 				for (VoiceStateObject voiceState : json.voice_states) {
-					final AtomicReference<IUser> user = new AtomicReference<>(guild.getUserByID(voiceState.user_id));
+					final AtomicReference<IUser> user = new AtomicReference<>(guild.getUserByID(Long.parseUnsignedLong(voiceState.user_id)));
 					if (user.get() == null) {
 						new RequestBuilder(shard.getClient()).shouldBufferRequests(true).doAction(() -> {
-							if (user.get() == null) user.set(shard.fetchUser(voiceState.user_id));
+							if (user.get() == null) user.set(shard.fetchUser(Long.parseUnsignedLong(voiceState.user_id)));
 							return true;
 						}).execute();
 					}
@@ -327,7 +328,7 @@ public class DiscordUtils {
 	 * @return The emoji object.
 	 */
 	public static IEmoji getEmojiFromJSON(IGuild guild, EmojiObject json) {
-		EmojiImpl emoji = new EmojiImpl(guild, json.id, json.name, json.require_colons, json.managed, json.roles);
+		EmojiImpl emoji = new EmojiImpl(guild, Long.parseUnsignedLong(json.id), json.name, json.require_colons, json.managed, json.roles);
 
 		return emoji;
 	}
@@ -366,18 +367,18 @@ public class DiscordUtils {
 	public static IUser getUserFromGuildMemberResponse(IGuild guild, MemberObject json) {
 		User user = getUserFromJSON(guild.getShard(), json.user);
 		for (String role : json.roles) {
-			Role roleObj = (Role) guild.getRoleByID(role);
+			Role roleObj = (Role) guild.getRoleByID(Long.parseUnsignedLong(role));
 			if (roleObj != null && !user.getRolesForGuild(guild).contains(roleObj))
-				user.addRole(guild.getID(), roleObj);
+				user.addRole(guild.getLongID(), roleObj);
 		}
-		user.addRole(guild.getID(), guild.getRoleByID(guild.getID())); //@everyone role
-		user.addNick(guild.getID(), json.nick);
+		user.addRole(guild.getLongID(), guild.getRoleByID(guild.getLongID())); //@everyone role
+		user.addNick(guild.getLongID(), json.nick);
 
 		VoiceState voiceState = (VoiceState) user.getVoiceStateForGuild(guild);
 		voiceState.setDeafened(json.deaf);
 		voiceState.setMuted(json.mute);
 
-		((Guild) guild).joinTimes.put(new Guild.TimeStampHolder(user.getID(), convertFromTimestamp(json.joined_at)));
+		((Guild) guild).joinTimes.put(new Guild.TimeStampHolder(user.getLongID(), convertFromTimestamp(json.joined_at)));
 		return user;
 	}
 
@@ -391,11 +392,11 @@ public class DiscordUtils {
 	public static IPrivateChannel getPrivateChannelFromJSON(IShard shard, PrivateChannelObject json) {
 		IPrivateChannel channel = ((ShardImpl) shard).privateChannels.get(json.id);
 		if (channel == null) {
-			User recipient = (User) shard.getUserByID(json.id);
+			User recipient = (User) shard.getUserByID(Long.parseUnsignedLong(json.id));
 			if (recipient == null)
 				recipient = getUserFromJSON(shard, json.recipient);
 
-			channel = new PrivateChannel((DiscordClientImpl) shard.getClient(), recipient, json.id);
+			channel = new PrivateChannel((DiscordClientImpl) shard.getClient(), recipient, Long.parseUnsignedLong(json.id));
 		}
 
 		return channel;
@@ -410,7 +411,7 @@ public class DiscordUtils {
 	 */
 	public static IMessage getMessageFromJSON(Channel channel, MessageObject json) {
 		if (channel.messages.containsKey(json.id)) {
-			Message message = (Message) channel.getMessageByID(json.id);
+			Message message = (Message) channel.getMessageByID(Long.parseUnsignedLong(json.id));
 			message.setAttachments(getAttachmentsFromJSON(json));
 			message.setEmbeds(getEmbedsFromJSON(json));
 			message.setContent(json.content);
@@ -424,18 +425,19 @@ public class DiscordUtils {
 
 			return message;
 		} else {
+			long authorId = Long.parseUnsignedLong(json.author.id);
 			IUser author = channel.getGuild() == null ? getUserFromJSON(channel.getShard(), json.author) : channel.getGuild()
 					.getUsers()
 					.stream()
-					.filter(it -> it.getID().equals(json.author.id))
+					.filter(it -> it.getLongID() == authorId)
 					.findAny()
 					.orElseGet(() -> getUserFromJSON(channel.getShard(), json.author));
-			Message message = new Message(channel.getClient(), json.id, json.content,
+			Message message = new Message(channel.getClient(), Long.parseUnsignedLong(json.id), json.content,
 					author, channel, convertFromTimestamp(json.timestamp),
 					json.edited_timestamp == null ? null : convertFromTimestamp(json.edited_timestamp),
 					json.mention_everyone, getMentionsFromJSON(json), getRoleMentionsFromJSON(json),
 					getAttachmentsFromJSON(json), Boolean.TRUE.equals(json.pinned), getEmbedsFromJSON(json),
-					getReactionsFromJson(channel.getShard(), json.reactions), json.webhook_id);
+					getReactionsFromJson(channel.getShard(), json.reactions), json.webhook_id != null ? Long.parseUnsignedLong(json.webhook_id) : null);
 
 			for (IReaction reaction : message.getReactions()) {
 				((Reaction) reaction).setMessage(message);
@@ -487,20 +489,22 @@ public class DiscordUtils {
 	 * @return The message object.
 	 */
 	public static IWebhook getWebhookFromJSON(IChannel channel, WebhookObject json) {
-		if (channel.getWebhookByID(json.id) != null) {
-			Webhook webhook = (Webhook) channel.getWebhookByID(json.id);
+		long webhookId = Long.parseUnsignedLong(json.id);
+		if (channel.getWebhookByID(webhookId) != null) {
+			Webhook webhook = (Webhook) channel.getWebhookByID(webhookId);
 			webhook.setName(json.name);
 			webhook.setAvatar(json.avatar);
 
 			return webhook;
 		} else {
+			long userId = Long.parseUnsignedLong(json.user.id);
 			IUser author = channel.getGuild()
 					.getUsers()
 					.stream()
-					.filter(it -> it.getID().equals(json.user.id))
+					.filter(it -> it.getLongID() == userId)
 					.findAny()
 					.orElseGet(() -> getUserFromJSON(channel.getShard(), json.user));
-			return new Webhook(channel.getClient(), json.name, json.id, channel, author, json.avatar, json.token);
+			return new Webhook(channel.getClient(), json.name, Long.parseUnsignedLong(json.id), channel, author, json.avatar, json.token);
 		}
 	}
 
@@ -519,7 +523,7 @@ public class DiscordUtils {
 		Cache<IChannel.PermissionOverride> userOverrides = overrides.getLeft();
 		Cache<IChannel.PermissionOverride> roleOverrides = overrides.getRight();
 
-		if ((channel = (Channel) guild.getChannelByID(json.id)) != null) {
+		if ((channel = (Channel) guild.getChannelByID(Long.parseUnsignedLong(json.id))) != null) {
 			channel.setName(json.name);
 			channel.setPosition(json.position);
 			channel.setTopic(json.topic);
@@ -528,7 +532,7 @@ public class DiscordUtils {
 			channel.roleOverrides.clear();
 			channel.roleOverrides.putAll(roleOverrides);
 		} else {
-			channel = new Channel((DiscordClientImpl) guild.getClient(), json.name, json.id, guild, json.topic, json.position,
+			channel = new Channel((DiscordClientImpl) guild.getClient(), json.name, Long.parseUnsignedLong(json.id), guild, json.topic, json.position,
 					roleOverrides, userOverrides);
 		}
 
@@ -549,10 +553,10 @@ public class DiscordUtils {
 		for (OverwriteObject overrides : overwrites) {
 			if (overrides.type.equalsIgnoreCase("role")) {
 				roleOverrides.put(new IChannel.PermissionOverride(Permissions.getAllowedPermissionsForNumber(overrides.allow),
-								Permissions.getDeniedPermissionsForNumber(overrides.deny), overrides.id));
+								Permissions.getDeniedPermissionsForNumber(overrides.deny), Long.parseUnsignedLong(overrides.id)));
 			} else if (overrides.type.equalsIgnoreCase("member")) {
 				userOverrides.put(new IChannel.PermissionOverride(Permissions.getAllowedPermissionsForNumber(overrides.allow),
-								Permissions.getDeniedPermissionsForNumber(overrides.deny), overrides.id));
+								Permissions.getDeniedPermissionsForNumber(overrides.deny), Long.parseUnsignedLong(overrides.id)));
 			} else {
 				Discord4J.LOGGER.warn(LogMarkers.API, "Unknown permissions overwrite type \"{}\"!", overrides.type);
 			}
@@ -570,7 +574,7 @@ public class DiscordUtils {
 	 */
 	public static IRole getRoleFromJSON(IGuild guild, RoleObject json) {
 		Role role;
-		if ((role = (Role) guild.getRoleByID(json.id)) != null) {
+		if ((role = (Role) guild.getRoleByID(Long.parseUnsignedLong(json.id))) != null) {
 			role.setColor(json.color);
 			role.setHoist(json.hoist);
 			role.setName(json.name);
@@ -578,7 +582,7 @@ public class DiscordUtils {
 			role.setPosition(json.position);
 			role.setMentionable(json.mentionable);
 		} else {
-			role = new Role(json.position, json.permissions, json.name, json.managed, json.id, json.hoist, json.color,
+			role = new Role(json.position, json.permissions, json.name, json.managed, Long.parseUnsignedLong(json.id), json.hoist, json.color,
 					json.mentionable, guild);
 			((Guild) guild).roles.put(role);
 		}
@@ -610,7 +614,7 @@ public class DiscordUtils {
 		Cache<IChannel.PermissionOverride> userOverrides = overrides.getLeft();
 		Cache<IChannel.PermissionOverride> roleOverrides = overrides.getRight();
 
-		if ((channel = (VoiceChannel) guild.getVoiceChannelByID(json.id)) != null) {
+		if ((channel = (VoiceChannel) guild.getVoiceChannelByID(Long.parseUnsignedLong(json.id))) != null) {
 			channel.setUserLimit(json.user_limit);
 			channel.setBitrate(json.bitrate);
 			channel.setName(json.name);
@@ -620,7 +624,7 @@ public class DiscordUtils {
 			channel.roleOverrides.clear();
 			channel.roleOverrides.putAll(roleOverrides);
 		} else {
-			channel = new VoiceChannel((DiscordClientImpl) guild.getClient(), json.name, json.id, guild, json.topic, json.position,
+			channel = new VoiceChannel((DiscordClientImpl) guild.getClient(), json.name, Long.parseUnsignedLong(json.id), guild, json.topic, json.position,
 					json.user_limit, json.bitrate, roleOverrides, userOverrides);
 		}
 
@@ -635,7 +639,8 @@ public class DiscordUtils {
 	 * @return The voice state object.
 	 */
 	public static IVoiceState getVoiceStateFromJson(IGuild guild, VoiceStateObject json) {
-		return new VoiceState(guild, guild.getVoiceChannelByID(json.channel_id), guild.getUserByID(json.user_id),
+		IVoiceChannel channel = json.channel_id != null ? guild.getVoiceChannelByID(Long.parseUnsignedLong(json.channel_id)) : null;
+		return new VoiceState(guild, channel, guild.getUserByID(Long.parseUnsignedLong(json.user_id)),
 				json.session_id, json.deaf, json.mute, json.self_deaf, json.self_mute, json.suppress);
 	}
 
@@ -809,8 +814,8 @@ public class DiscordUtils {
 	 * @param id The id.
 	 * @return The time the id was created.
 	 */
-	public static LocalDateTime getSnowflakeTimeFromID(String id) {
-		long milliseconds = DISCORD_EPOCH.add(new BigInteger(id).shiftRight(22)).longValue();
+	public static LocalDateTime getSnowflakeTimeFromID(long id) {
+		long milliseconds = DISCORD_EPOCH + (id >>> 22);
 		return LocalDateTime.ofInstant(Instant.ofEpochMilli(milliseconds), ZoneId.systemDefault());
 	}
 
@@ -919,7 +924,7 @@ public class DiscordUtils {
 
 		if (!a.getClass().isAssignableFrom(b.getClass())) return false;
 
-		if (!((IDiscordObject) a).getID().equals(((IDiscordObject) b).getID())) return false;
+		if (((IDiscordObject) a).getLongID() != ((IDiscordObject) b).getLongID()) return false;
 
 		return true;
 	}

--- a/src/main/java/sx/blah/discord/api/internal/DiscordVoiceWS.java
+++ b/src/main/java/sx/blah/discord/api/internal/DiscordVoiceWS.java
@@ -64,7 +64,7 @@ public class DiscordVoiceWS extends WebSocketAdapter implements IIDLinkedObject 
 		this.shard = (ShardImpl) shard;
 		this.endpoint = event.endpoint.replace(":80", "");
 		this.token = event.token;
-		this.guild = shard.getGuildByID(event.guild_id);
+		this.guild = shard.getGuildByID(Long.parseUnsignedLong(event.guild_id));
 	}
 
 	void connect() {
@@ -85,7 +85,7 @@ public class DiscordVoiceWS extends WebSocketAdapter implements IIDLinkedObject 
 		super.onWebSocketConnect(sess);
 		Discord4J.LOGGER.info(LogMarkers.VOICE_WEBSOCKET, "Voice Websocket Connected.");
 
-		send(VoiceOps.IDENTIFY, new VoiceIdentifyRequest(guild.getID(), shard.getClient().getOurUser().getID(), shard.ws.sessionId, token));
+		send(VoiceOps.IDENTIFY, new VoiceIdentifyRequest(guild.getStringID(), shard.getClient().getOurUser().getStringID(), shard.ws.sessionId, token));
 	}
 
 	@Override
@@ -112,7 +112,7 @@ public class DiscordVoiceWS extends WebSocketAdapter implements IIDLinkedObject 
 					break;
 				case SPEAKING:
 					VoiceSpeakingResponse response = DiscordUtils.MAPPER.treeToValue(d, VoiceSpeakingResponse.class);
-					IUser user = getGuild().getUserByID(response.user_id);
+					IUser user = getGuild().getUserByID(Long.parseUnsignedLong(response.user_id));
 					users.put(response.ssrc, user);
 					guild.getClient().getDispatcher().dispatch(new UserSpeakingEvent(user.getVoiceStateForGuild(guild).getChannel(), user, response.ssrc, response.speaking));
 					break;
@@ -139,7 +139,7 @@ public class DiscordVoiceWS extends WebSocketAdapter implements IIDLinkedObject 
 	public void disconnect(VoiceDisconnectedEvent.Reason reason) {
 		try {
 			shard.getClient().getDispatcher().dispatch(new VoiceDisconnectedEvent(getGuild(), reason));
-			shard.voiceWebSockets.remove(guild.getID());
+			shard.voiceWebSockets.remove(guild.getLongID());
 			heartbeat.shutdownNow();
 			voiceSocket.shutdown();
 			if (getSession() != null) getSession().close(1000, null); // Discord doesn't care about the reason
@@ -177,7 +177,7 @@ public class DiscordVoiceWS extends WebSocketAdapter implements IIDLinkedObject 
 	}
 
 	@Override
-	public String getID() {
-		return guild.getID();
+	public long getLongID() {
+		return guild.getLongID();
 	}
 }

--- a/src/main/java/sx/blah/discord/api/internal/json/requests/BulkDeleteRequest.java
+++ b/src/main/java/sx/blah/discord/api/internal/json/requests/BulkDeleteRequest.java
@@ -37,6 +37,6 @@ public class BulkDeleteRequest {
 	}
 
 	public BulkDeleteRequest(List<IMessage> messages) {
-		this(messages.stream().map(IDiscordObject::getID).toArray(String[]::new));
+		this(messages.stream().map(IDiscordObject::getStringID).toArray(String[]::new));
 	}
 }

--- a/src/main/java/sx/blah/discord/api/internal/json/requests/MemberEditRequest.java
+++ b/src/main/java/sx/blah/discord/api/internal/json/requests/MemberEditRequest.java
@@ -103,7 +103,7 @@ public class MemberEditRequest {
 	private final String channel_id;
 
 	MemberEditRequest(IRole[] roles, String nick, Boolean mute, Boolean deaf, String channelID) {
-		this.roles = roles == null ? null : Arrays.stream(roles).map(IRole::getID).distinct().toArray(String[]::new);
+		this.roles = roles == null ? null : Arrays.stream(roles).map(IRole::getStringID).distinct().toArray(String[]::new);
 		this.nick = nick;
 		this.mute = mute;
 		this.deaf = deaf;

--- a/src/main/java/sx/blah/discord/handle/impl/events/GuildUnavailableEvent.java
+++ b/src/main/java/sx/blah/discord/handle/impl/events/GuildUnavailableEvent.java
@@ -26,12 +26,12 @@ import sx.blah.discord.handle.obj.IGuild;
  */
 @Deprecated
 public class GuildUnavailableEvent extends sx.blah.discord.handle.impl.events.guild.GuildUnavailableEvent {
-	
+
 	public GuildUnavailableEvent(IGuild guild) {
 		super(guild);
 	}
-	
-	public GuildUnavailableEvent(String id) {
+
+	public GuildUnavailableEvent(long id) {
 		super(id);
 	}
 }

--- a/src/main/java/sx/blah/discord/handle/impl/events/guild/GuildUnavailableEvent.java
+++ b/src/main/java/sx/blah/discord/handle/impl/events/guild/GuildUnavailableEvent.java
@@ -27,14 +27,14 @@ import java.util.Optional;
  */
 public class GuildUnavailableEvent extends GuildEvent {
 
-	private final String id;
+	private final long id;
 
 	public GuildUnavailableEvent(IGuild guild) {
 		super(guild);
-		this.id = guild.getID();
+		this.id = guild.getLongID();
 	}
 
-	public GuildUnavailableEvent(String id) {
+	public GuildUnavailableEvent(long id) {
 		super(null);
 		this.id = id;
 	}
@@ -52,8 +52,19 @@ public class GuildUnavailableEvent extends GuildEvent {
 	 * Gets the id of the guild that became unavailable. This is always available.
 	 *
 	 * @return The unavailable guild.
+	 * @deprecated Use {@link #getGuildLongID()} instead
 	 */
+	@Deprecated
 	public String getGuildID() {
+		return Long.toUnsignedString(id);
+	}
+
+	/**
+	 * Gets the id of the guild that became unavailable. This is always available.
+	 *
+	 * @return The unavailable guild.
+	 */
+	public long getGuildLongID() {
 		return id;
 	}
 }

--- a/src/main/java/sx/blah/discord/handle/impl/obj/Channel.java
+++ b/src/main/java/sx/blah/discord/handle/impl/obj/Channel.java
@@ -36,6 +36,7 @@ import sx.blah.discord.handle.impl.events.WebhookUpdateEvent;
 import sx.blah.discord.handle.obj.*;
 import sx.blah.discord.util.*;
 import sx.blah.discord.util.cache.Cache;
+import sx.blah.discord.util.cache.LongMap;
 
 import java.io.*;
 import java.time.LocalDateTime;
@@ -61,7 +62,7 @@ public class Channel implements IChannel {
 	/**
 	 * Channel ID.
 	 */
-	protected final String id;
+	protected final long id;
 
 	/**
 	 * Messages that have been sent into this channel
@@ -118,7 +119,7 @@ public class Channel implements IChannel {
 	 */
 	protected final DiscordClientImpl client;
 
-	public Channel(DiscordClientImpl client, String name, String id, IGuild guild, String topic, int position, Cache<PermissionOverride> roleOverrides, Cache<PermissionOverride> userOverrides) {
+	public Channel(DiscordClientImpl client, String name, long id, IGuild guild, String topic, int position, Cache<PermissionOverride> roleOverrides, Cache<PermissionOverride> userOverrides) {
 		this.client = client;
 		this.name = name;
 		this.id = id;
@@ -147,7 +148,7 @@ public class Channel implements IChannel {
 	}
 
 	@Override
-	public String getID() {
+	public long getLongID() {
 		return id;
 	}
 
@@ -174,13 +175,13 @@ public class Channel implements IChannel {
 		}
 	}
 
-	private IMessage[] requestHistory(String before, int limit) {
+	private IMessage[] requestHistory(Long before, int limit) {
 		DiscordUtils.checkPermissions(client, this, EnumSet.of(Permissions.READ_MESSAGES, Permissions.READ_MESSAGE_HISTORY));
 
 		String queryParams = "?limit=" + limit;
 
 		if (before != null) {
-			queryParams += "&before=" + before;
+			queryParams += "&before=" + Long.toUnsignedString(before);
 		}
 //		} else if (around != null) {
 //			queryParams += "&around="+around;
@@ -208,12 +209,11 @@ public class Channel implements IChannel {
 		return new MessageHistory(messages.values());
 	}
 
-	private Collection<IMessage> subDeque(int from, int end) {
+	private static Collection<IMessage> subDeque(int from, int end, IMessage[] array) {
 		List<IMessage> list = new ArrayList<>();
-		Collection<IMessage> messages = this.messages.values();
 		if (from >= 0 || end < from) { //Skip this step if the indexes are invalid
 			for (int i = from; i < end; i++)
-				list.add((IMessage) messages.toArray()[i]);
+				list.add(array[i]);
 		}
 		return list;
 	}
@@ -221,14 +221,14 @@ public class Channel implements IChannel {
 	@Override
 	public MessageHistory getMessageHistory(int messageCount) {
 		if (messageCount <= messages.size())
-			return new MessageHistory(subDeque(0, messageCount));
+			return new MessageHistory(new ArrayList<>(messages.values()));
 		else {
 			final AtomicInteger remaining = new AtomicInteger(messageCount - messages.size());
 			final List<IMessage> retrieved = new ArrayList<>(messages.values());
 			while (remaining.get() > 0) {
 				RequestBuffer.request(() -> {
 					int requestCount = Math.min(remaining.get(), MESSAGE_CHUNK_COUNT);
-					IMessage[] chunk = requestHistory(retrieved.size() > 0 ? retrieved.get(retrieved.size()-1).getID() : null, requestCount);
+					IMessage[] chunk = requestHistory(retrieved.size() > 0 ? retrieved.get(retrieved.size()-1).getLongID() : null, requestCount);
 
 					if (requestCount != chunk.length)
 						remaining.set(0); //Got all possible messages already
@@ -254,7 +254,7 @@ public class Channel implements IChannel {
 				.filter(msg -> msg.getTimestamp().compareTo(startDate) <= 0)
 				.collect(Collectors.toList()));
 
-		final AtomicReference<String> lastID = new AtomicReference<>(retrieved.size() > 0 ? retrieved.get(retrieved.size()-1).getID() : null);
+		final AtomicReference<Long> lastID = new AtomicReference<>(retrieved.size() > 0 ? retrieved.get(retrieved.size()-1).getLongID() : null);
 		while ((maxCount > 0 && retrieved.size() < maxCount) || maxCount <= 0) {
 			if (RequestBuffer.request(() -> {
 				IMessage[] chunk = requestHistory(lastID.get(), MESSAGE_CHUNK_COUNT);
@@ -266,7 +266,7 @@ public class Channel implements IChannel {
 				retrieved.addAll(toAdd);
 
 				if (chunk.length > 0)
-					lastID.set(chunk[chunk.length-1].getID());
+					lastID.set(chunk[chunk.length-1].getLongID());
 
 				return chunk.length != MESSAGE_CHUNK_COUNT || (maxCount > 0 && retrieved.size() >= maxCount);//Done when the messages retrieved are not matching the requested count
 			}).get())
@@ -293,7 +293,7 @@ public class Channel implements IChannel {
 		if (messages.size() == retrieved.size()) { //All elements were copied over, meaning that we're likely not done finding messages
 			while ((maxCount > 0 && retrieved.size() < maxCount) || maxCount <= 0) {
 				if (RequestBuffer.request(() -> {
-					IMessage[] chunk = requestHistory(retrieved.size() > 0 ? retrieved.get(retrieved.size()-1).getID() : null, MESSAGE_CHUNK_COUNT);
+					IMessage[] chunk = requestHistory(retrieved.size() > 0 ? retrieved.get(retrieved.size()-1).getLongID() : null, MESSAGE_CHUNK_COUNT);
 
 					List<IMessage> toAdd = Arrays.stream(chunk)
 							.filter(msg -> msg.getTimestamp().compareTo(endDate) >= 0)
@@ -324,7 +324,7 @@ public class Channel implements IChannel {
 				.filter(msg -> msg.getTimestamp().compareTo(startDate) >= 0 && msg.getTimestamp().compareTo(endDate) <= 0)
 				.collect(Collectors.toList()));
 
-		final AtomicReference<String> lastID = new AtomicReference<>(retrieved.size() > 0 ? retrieved.get(retrieved.size()-1).getID() : null);
+		final AtomicReference<Long> lastID = new AtomicReference<>(retrieved.size() > 0 ? retrieved.get(retrieved.size()-1).getLongID() : null);
 
 		if (((IMessage) messages.values().toArray()[messages.size()-1]).getTimestamp().compareTo(endDate) <= 0) { //When the last message cached matches the criteria there may still be more in history
 			while ((maxCount > 0 && retrieved.size() < maxCount) || maxCount <= 0) {
@@ -338,7 +338,7 @@ public class Channel implements IChannel {
 					retrieved.addAll(toAdd);
 
 					if (chunk.length > 0)
-						lastID.set(chunk[chunk.length-1].getID());
+						lastID.set(chunk[chunk.length-1].getLongID());
 
 					return toAdd.size() != chunk.length || chunk.length != MESSAGE_CHUNK_COUNT || (maxCount > 0 && retrieved.size() >= maxCount); //We reached the end of the history or we reached the specified end date
 				}).get())
@@ -353,26 +353,27 @@ public class Channel implements IChannel {
 	}
 
 	@Override
-	public MessageHistory getMessageHistoryFrom(String id) {
+	public MessageHistory getMessageHistoryFrom(long id) {
 		return getMessageHistoryFrom(id, -1);
 	}
 
 	@Override
-	public MessageHistory getMessageHistoryFrom(String id, int maxCount) {
+	public MessageHistory getMessageHistoryFrom(long id, int maxCount) {
+		IMessage[] array = messages.values().toArray(new IMessage[messages.size()]);
 		int index = -1;
-		for (int i = 0; i < messages.size(); i++) {
-			if (((IMessage) messages.values().toArray()[i]).getID().equals(id)) {
+		for (int i = 0; i < array.length; i++) {
+			if (array[i].getLongID() == id) {
 				index = i;
 				break;
 			}
 		}
 
-		final List<IMessage> retrieved = new ArrayList<>(subDeque(index, messages.size()));
+		final List<IMessage> retrieved = new ArrayList<>(subDeque(index, array.length, array));
 
 		if (index == -1)
 			retrieved.add(RequestBuffer.request(() -> {return getMessageByID(id);}).get()); //Ignore intellij on this line, the return statement is required for the IRequest to not resolve to an IVoidRequest
 
-		final AtomicReference<String> lastID = new AtomicReference<>(retrieved.size() > 0 ? retrieved.get(retrieved.size()-1).getID() : null);
+		final AtomicReference<Long> lastID = new AtomicReference<>(retrieved.size() > 0 ? retrieved.get(retrieved.size()-1).getLongID() : null);
 		while ((maxCount > 0 && retrieved.size() < maxCount) || maxCount <= 0) {
 			if (RequestBuffer.request(() -> {
 				IMessage[] chunk = requestHistory(lastID.get(), MESSAGE_CHUNK_COUNT);
@@ -380,7 +381,7 @@ public class Channel implements IChannel {
 				retrieved.addAll(Arrays.asList(chunk));
 
 				if (chunk.length > 0)
-					lastID.set(chunk[chunk.length-1].getID());
+					lastID.set(chunk[chunk.length-1].getLongID());
 
 				return chunk.length != MESSAGE_CHUNK_COUNT || (maxCount > 0 && retrieved.size() >= maxCount); //We reached the end of the history or we reached the specified end date
 			}).get())
@@ -394,27 +395,27 @@ public class Channel implements IChannel {
 	}
 
 	@Override
-	public MessageHistory getMessageHistoryTo(String id) {
+	public MessageHistory getMessageHistoryTo(long id) {
 		return getMessageHistoryTo(id, -1);
 	}
 
 	@Override
-	public MessageHistory getMessageHistoryTo(String id, int maxCount) {
+	public MessageHistory getMessageHistoryTo(long id, int maxCount) {
 		final List<IMessage> retrieved = new ArrayList<>();
 
 		for (IMessage message : messages.values()) {
 			retrieved.add(message);
-			if (message.getID().equals(id))
+			if (message.getLongID() == id)
 				return new MessageHistory(retrieved); //Let's end early since we reached the target
 		}
 
 		while ((maxCount > 0 && retrieved.size() < maxCount) || maxCount <= 0) {
 			if (RequestBuffer.request(() -> {
-				IMessage[] chunk = requestHistory(retrieved.size() > 0 ? retrieved.get(retrieved.size()-1).getID() : null, MESSAGE_CHUNK_COUNT);
+				IMessage[] chunk = requestHistory(retrieved.size() > 0 ? retrieved.get(retrieved.size()-1).getLongID() : null, MESSAGE_CHUNK_COUNT);
 
 				for (IMessage message : chunk) {
 					retrieved.add(message);
-					if (message.getID().equals(id))
+					if (message.getLongID() == id)
 						return true; //Finish early
 				}
 
@@ -430,26 +431,27 @@ public class Channel implements IChannel {
 	}
 
 	@Override
-	public MessageHistory getMessageHistoryIn(String beginID, String endID) {
+	public MessageHistory getMessageHistoryIn(long beginID, long endID) {
 		return getMessageHistoryIn(beginID, endID, -1);
 	}
 
 	@Override
-	public MessageHistory getMessageHistoryIn(String beginID, String endID, int maxCount) {
+	public MessageHistory getMessageHistoryIn(long beginID, long endID, int maxCount) {
+		IMessage[] array = messages.values().toArray(new IMessage[messages.size()]);
 		int startIndex = -1;
-		for (int i = 0; i < messages.size(); i++) {
-			if (((IMessage) messages.values().toArray()[i]).getID().equals(id)) {
+		for (int i = 0; i < array.length; i++) {
+			if (array[i].getLongID() == id) {
 				startIndex = i;
 				break;
 			}
 		}
 
-		final List<IMessage> retrieved = new ArrayList<>(subDeque(startIndex, messages.size()));
+		final List<IMessage> retrieved = new ArrayList<>(subDeque(startIndex, array.length, array));
 
 		if (startIndex == -1)
 			retrieved.add(RequestBuffer.request(() -> {return getMessageByID(id);}).get()); //Ignore intellij on this line, the return statement is required for the IRequest to not resolve to an IVoidRequest
 
-		final AtomicReference<String> lastID = new AtomicReference<>(retrieved.size() > 0 ? retrieved.get(retrieved.size()-1).getID() : null);
+		final AtomicReference<Long> lastID = new AtomicReference<>(retrieved.size() > 0 ? retrieved.get(retrieved.size()-1).getLongID() : null);
 
 		while ((maxCount > 0 && retrieved.size() < maxCount) || maxCount <= 0) {
 			if (RequestBuffer.request(() -> {
@@ -457,12 +459,12 @@ public class Channel implements IChannel {
 
 				for (IMessage message : chunk) {
 					retrieved.add(message);
-					if (message.getID().equals(id))
+					if (message.getLongID() == id)
 						return true; //Finish early
 				}
 
 				if (chunk.length > 0)
-					lastID.set(chunk[chunk.length-1].getID());
+					lastID.set(chunk[chunk.length-1].getLongID());
 
 				return chunk.length != MESSAGE_CHUNK_COUNT || (maxCount > 0 && retrieved.size() >= maxCount); //We reached the end of the history or we reached the specified end date
 			}).get())
@@ -481,7 +483,7 @@ public class Channel implements IChannel {
 
 		while (true) {
 			if (RequestBuffer.request(() -> {
-				IMessage[] chunk = requestHistory(retrieved.size() > 0 ? retrieved.get(retrieved.size()-1).getID() : null, MESSAGE_CHUNK_COUNT);
+				IMessage[] chunk = requestHistory(retrieved.size() > 0 ? retrieved.get(retrieved.size()-1).getLongID() : null, MESSAGE_CHUNK_COUNT);
 
 				retrieved.addAll(Arrays.asList(chunk));
 
@@ -511,7 +513,7 @@ public class Channel implements IChannel {
 		}
 
 		List<IMessage> toDelete = messages.stream()
-				.filter(msg -> Long.parseLong(msg.getID()) >= (((System.currentTimeMillis() - 14 * 24 * 60 * 60 * 1000) - 1420070400000L) << 22)) // Taken from Jake
+				.filter(msg -> msg.getLongID() >= (((System.currentTimeMillis() - 14 * 24 * 60 * 60 * 1000) - 1420070400000L) << 22)) // Taken from Jake
 				.collect(Collectors.toList());
 
 		if (toDelete.size() < 1)
@@ -545,15 +547,20 @@ public class Channel implements IChannel {
 	}
 
 	@Override
+	@Deprecated
 	public IMessage getMessageByID(String messageID) {
 		if (messageID == null)
 			return null;
+		return getMessageByID(Long.parseUnsignedLong(messageID));
+	}
 
+	@Override
+	public IMessage getMessageByID(long messageID) {
 		return messages.getOrElseGet(messageID, () -> {
 					DiscordUtils.checkPermissions(client, this, EnumSet.of(Permissions.READ_MESSAGES, Permissions.READ_MESSAGE_HISTORY));
 					return RequestBuffer.request(() -> {
 						return DiscordUtils.getMessageFromJSON(this, client.REQUESTS.GET.makeRequest(
-								DiscordEndpoints.CHANNELS + this.getID() + "/messages/" + messageID,
+								DiscordEndpoints.CHANNELS + this.getStringID() + "/messages/" + messageID,
 								MessageObject.class));
 					}).get();
 				});
@@ -585,7 +592,7 @@ public class Channel implements IChannel {
 
 	@Override
 	public String mention() {
-		return "<#" + this.getID() + ">";
+		return "<#" + this.getStringID() + ">";
 	}
 
 	@Override
@@ -737,7 +744,7 @@ public class Channel implements IChannel {
 		DiscordUtils.checkPermissions(client, this, EnumSet.of(Permissions.CREATE_INVITE));
 
 		ExtendedInviteObject response = ((DiscordClientImpl) client).REQUESTS.POST.makeRequest(
-				DiscordEndpoints.CHANNELS+getID()+"/invites",
+				DiscordEndpoints.CHANNELS+getStringID()+"/invites",
 				new InviteCreateRequest(maxAge, maxUses, temporary, unique),
 				ExtendedInviteObject.class);
 
@@ -762,7 +769,7 @@ public class Channel implements IChannel {
 						return;
 					}
 					try {
-						((DiscordClientImpl) client).REQUESTS.POST.makeRequest(DiscordEndpoints.CHANNELS + getID() + "/typing");
+						((DiscordClientImpl) client).REQUESTS.POST.makeRequest(DiscordEndpoints.CHANNELS + getLongID() + "/typing");
 					} catch (RateLimitException | DiscordException e) {
 						Discord4J.LOGGER.error(LogMarkers.HANDLE, "Discord4J Internal Exception", e);
 					}
@@ -835,27 +842,27 @@ public class Channel implements IChannel {
 	}
 
 	@Override
-	public Map<String, PermissionOverride> getUserOverrides() {
+	public LongMap<PermissionOverride> getUserOverridesLong() {
 		return userOverrides.mapCopy();
 	}
 
 	@Override
-	public Map<String, PermissionOverride> getRoleOverrides() {
+	public LongMap<PermissionOverride> getRoleOverridesLong() {
 		return roleOverrides.mapCopy();
 	}
 
 	@Override
 	public EnumSet<Permissions> getModifiedPermissions(IUser user) {
-		if (isPrivate() || getGuild().getOwnerID().equals(user.getID()))
+		if (isPrivate() || getGuild().getOwnerLongID() == user.getLongID())
 			return EnumSet.allOf(Permissions.class);
 
 		List<IRole> roles = user.getRolesForGuild(guild);
 		EnumSet<Permissions> permissions = user.getPermissionsForGuild(guild);
 
-		PermissionOverride override = userOverrides.get(user.getID());
+		PermissionOverride override = userOverrides.get(user.getLongID());
 		List<PermissionOverride> overrideRoles = roles.stream()
-				.filter(r -> roleOverrides.containsKey(r.getID()))
-				.map(role -> roleOverrides.get(role.getID()))
+				.filter(r -> roleOverrides.containsKey(r.getLongID()))
+				.map(role -> roleOverrides.get(role.getLongID()))
 				.collect(Collectors.toList());
 		Collections.reverse(overrideRoles);
 		for (PermissionOverride roleOverride : overrideRoles) {
@@ -874,10 +881,10 @@ public class Channel implements IChannel {
 	@Override
 	public EnumSet<Permissions> getModifiedPermissions(IRole role) {
 		EnumSet<Permissions> base = role.getPermissions();
-		PermissionOverride override = roleOverrides.get(role.getID());
+		PermissionOverride override = roleOverrides.get(role.getLongID());
 
 		if (override == null) {
-			if ((override = roleOverrides.get(guild.getEveryoneRole().getID())) == null)
+			if ((override = roleOverrides.get(guild.getEveryoneRole().getLongID())) == null)
 				return base;
 		}
 
@@ -891,35 +898,35 @@ public class Channel implements IChannel {
 	public void removePermissionsOverride(IUser user) {
 		DiscordUtils.checkPermissions(client, this, user.getRolesForGuild(guild), EnumSet.of(Permissions.MANAGE_PERMISSIONS));
 
-		((DiscordClientImpl) client).REQUESTS.DELETE.makeRequest(DiscordEndpoints.CHANNELS+getID()+"/permissions/"+user.getID());
+		((DiscordClientImpl) client).REQUESTS.DELETE.makeRequest(DiscordEndpoints.CHANNELS+getStringID()+"/permissions/"+user.getStringID());
 
-		userOverrides.remove(user.getID());
+		userOverrides.remove(user.getLongID());
 	}
 
 	@Override
 	public void removePermissionsOverride(IRole role) {
 		DiscordUtils.checkPermissions(client, this, Collections.singletonList(role), EnumSet.of(Permissions.MANAGE_PERMISSIONS));
 
-		((DiscordClientImpl) client).REQUESTS.DELETE.makeRequest(DiscordEndpoints.CHANNELS+getID()+"/permissions/"+role.getID());
+		((DiscordClientImpl) client).REQUESTS.DELETE.makeRequest(DiscordEndpoints.CHANNELS+getStringID()+"/permissions/"+role.getStringID());
 
-		roleOverrides.remove(role.getID());
+		roleOverrides.remove(role.getLongID());
 	}
 
 	@Override
 	public void overrideRolePermissions(IRole role, EnumSet<Permissions> toAdd, EnumSet<Permissions> toRemove) {
-		overridePermissions("role", role.getID(), toAdd, toRemove);
+		overridePermissions("role", role.getStringID(), toAdd, toRemove);
 	}
 
 	@Override
 	public void overrideUserPermissions(IUser user, EnumSet<Permissions> toAdd, EnumSet<Permissions> toRemove) {
-		overridePermissions("member", user.getID(), toAdd, toRemove);
+		overridePermissions("member", user.getStringID(), toAdd, toRemove);
 	}
 
 	private void overridePermissions(String type, String id, EnumSet<Permissions> toAdd, EnumSet<Permissions> toRemove) {
 		DiscordUtils.checkPermissions(client, this, EnumSet.of(Permissions.MANAGE_PERMISSIONS));
 
 		((DiscordClientImpl) client).REQUESTS.PUT.makeRequest(
-				DiscordEndpoints.CHANNELS+getID()+"/permissions/"+id,
+				DiscordEndpoints.CHANNELS+getStringID()+"/permissions/"+id,
 				new OverwriteObject(type, null, Permissions.generatePermissionsNumber(toAdd), Permissions.generatePermissionsNumber(toRemove)));
 	}
 
@@ -968,7 +975,7 @@ public class Channel implements IChannel {
 		if (message.isPinned())
 			throw new DiscordException("Message already pinned!");
 
-		((DiscordClientImpl) client).REQUESTS.PUT.makeRequest(DiscordEndpoints.CHANNELS + id + "/pins/" + message.getID());
+		((DiscordClientImpl) client).REQUESTS.PUT.makeRequest(DiscordEndpoints.CHANNELS + id + "/pins/" + message.getStringID());
 	}
 
 	@Override
@@ -981,7 +988,7 @@ public class Channel implements IChannel {
 		if (!message.isPinned())
 			throw new DiscordException("Message already unpinned!");
 
-		((DiscordClientImpl) client).REQUESTS.DELETE.makeRequest(DiscordEndpoints.CHANNELS + id + "/pins/" + message.getID());
+		((DiscordClientImpl) client).REQUESTS.DELETE.makeRequest(DiscordEndpoints.CHANNELS + id + "/pins/" + message.getStringID());
 	}
 
 	@Override
@@ -990,7 +997,7 @@ public class Channel implements IChannel {
 	}
 
 	@Override
-	public IWebhook getWebhookByID(String id) {
+	public IWebhook getWebhookByID(long id) {
 		return webhooks.get(id);
 	}
 
@@ -1020,7 +1027,7 @@ public class Channel implements IChannel {
 			throw new DiscordException("Webhook name can only be between 2 and 32 characters!");
 
 		WebhookObject response = ((DiscordClientImpl) client).REQUESTS.POST.makeRequest(
-				DiscordEndpoints.CHANNELS + getID() + "/webhooks",
+				DiscordEndpoints.CHANNELS + getStringID() + "/webhooks",
 				new WebhookCreateRequest(name, avatar),
 				WebhookObject.class);
 
@@ -1045,17 +1052,18 @@ public class Channel implements IChannel {
 						.collect(Collectors.toCollection(CopyOnWriteArrayList::new));
 
 				WebhookObject[] response = ((DiscordClientImpl) client).REQUESTS.GET.makeRequest(
-						DiscordEndpoints.CHANNELS + getID() + "/webhooks",
+						DiscordEndpoints.CHANNELS + getStringID() + "/webhooks",
 						WebhookObject[].class);
 
 				if (response != null) {
 					for (WebhookObject webhookObject : response) {
-						if (getWebhookByID(webhookObject.id) == null) {
+						long webhookId = Long.parseUnsignedLong(webhookObject.id);
+						if (getWebhookByID(webhookId) == null) {
 							IWebhook newWebhook = DiscordUtils.getWebhookFromJSON(this, webhookObject);
 							client.getDispatcher().dispatch(new WebhookCreateEvent(newWebhook));
 							webhooks.put(newWebhook);
 						} else {
-							IWebhook toUpdate = getWebhookByID(webhookObject.id);
+							IWebhook toUpdate = getWebhookByID(webhookId);
 							IWebhook oldWebhook = toUpdate.copy();
 							toUpdate = DiscordUtils.getWebhookFromJSON(this, webhookObject);
 							if (!oldWebhook.getDefaultName().equals(toUpdate.getDefaultName()) || !String.valueOf(oldWebhook.getDefaultAvatar()).equals(String.valueOf(toUpdate.getDefaultAvatar())))

--- a/src/main/java/sx/blah/discord/handle/impl/obj/EmojiImpl.java
+++ b/src/main/java/sx/blah/discord/handle/impl/obj/EmojiImpl.java
@@ -41,7 +41,7 @@ public class EmojiImpl implements IEmoji {
 	/**
 	 * The ID.
 	 */
-	protected final String id;
+	protected final long id;
 	/**
 	 * Roles for integration?
 	 */
@@ -59,11 +59,15 @@ public class EmojiImpl implements IEmoji {
 	 */
 	protected volatile boolean isManaged;
 
-	public EmojiImpl(IGuild guild, String id, String name, boolean requiresColons, boolean isManaged, IRole[] roles) {
+	public EmojiImpl(IGuild guild, long id, String name, boolean requiresColons, boolean isManaged, String[] roles) {
+		this(guild, id, name, requiresColons, isManaged, convertStringsToLongs(roles));
+	}
+
+	public EmojiImpl(IGuild guild, long id, String name, boolean requiresColons, boolean isManaged, IRole[] roles) {
 		this(guild, id, name, requiresColons, isManaged, convertRolesToIDs(roles));
 	}
 
-	public EmojiImpl(IGuild guild, String id, String name, boolean requiresColons, boolean isManaged, String[] roleIds) {
+	public EmojiImpl(IGuild guild, long id, String name, boolean requiresColons, boolean isManaged, long[] roleIds) {
 		this.guild = guild;
 		this.id = id;
 		this.name = name;
@@ -71,7 +75,7 @@ public class EmojiImpl implements IEmoji {
 		this.isManaged = isManaged;
 		this.roles = new Cache<>((DiscordClientImpl) guild.getClient(), IRole.class);
 
-		for (String roleId : roleIds) {
+		for (long roleId : roleIds) {
 			IRole role = guild.getRoleByID(roleId);
 
 			if (role != null) {
@@ -80,8 +84,12 @@ public class EmojiImpl implements IEmoji {
 		}
 	}
 
-	private static String[] convertRolesToIDs(IRole[] roles) {
-		return Arrays.stream(roles).filter(role -> role != null).map(IRole::getID).toArray(String[]::new);
+	private static long[] convertRolesToIDs(IRole[] roles) {
+		return Arrays.stream(roles).filter(role -> role != null).mapToLong(IRole::getLongID).toArray();
+	}
+
+	private static long[] convertStringsToLongs(String[] roles) {
+		return Arrays.stream(roles).mapToLong(Long::parseUnsignedLong).toArray();
 	}
 
 	public void setRequiresColons(boolean requiresColons) {
@@ -89,7 +97,7 @@ public class EmojiImpl implements IEmoji {
 	}
 
 	@Override
-	public String getID() {
+	public long getLongID() {
 		return id;
 	}
 
@@ -143,12 +151,12 @@ public class EmojiImpl implements IEmoji {
 
 	@Override
 	public String getImageUrl() {
-		return String.format(DiscordEndpoints.EMOJI_IMAGE, getID());
+		return String.format(DiscordEndpoints.EMOJI_IMAGE, getStringID());
 	}
 
 	@Override
 	public String toString() {
-		return "<:" + getName() + ":" + getID() + ">";
+		return "<:" + getName() + ":" + getStringID() + ">";
 	}
 
 	@Override

--- a/src/main/java/sx/blah/discord/handle/impl/obj/Guild.java
+++ b/src/main/java/sx/blah/discord/handle/impl/obj/Guild.java
@@ -74,7 +74,7 @@ public class Guild implements IGuild {
 	/**
 	 * The ID of this guild.
 	 */
-	protected final String id;
+	protected final long id;
 
 	/**
 	 * The location of the guild icon
@@ -89,7 +89,7 @@ public class Guild implements IGuild {
 	/**
 	 * The user id for the owner of the guild
 	 */
-	protected volatile String ownerID;
+	protected volatile long ownerID;
 
 	/**
 	 * The roles the guild contains.
@@ -99,7 +99,7 @@ public class Guild implements IGuild {
 	/**
 	 * The channel where those who are afk are moved to.
 	 */
-	protected volatile String afkChannel;
+	protected volatile long afkChannel;
 	/**
 	 * The time in seconds for a user to be idle to be determined as "afk".
 	 */
@@ -140,14 +140,14 @@ public class Guild implements IGuild {
 	 */
 	private int totalMemberCount;
 
-	public Guild(IShard shard, String name, String id, String icon, String ownerID, String afkChannel, int afkTimeout, String region, int verification) {
+	public Guild(IShard shard, String name, long id, String icon, long ownerID, long afkChannel, int afkTimeout, String region, int verification) {
 		this(shard, name, id, icon, ownerID, afkChannel, afkTimeout, region, verification,
 				new Cache<>((DiscordClientImpl) shard.getClient(), IRole.class), new Cache<>((DiscordClientImpl) shard.getClient(), IChannel.class),
 				new Cache<>((DiscordClientImpl) shard.getClient(), IVoiceChannel.class), new Cache<>((DiscordClientImpl) shard.getClient(), IUser.class),
 				new Cache<>((DiscordClientImpl) shard.getClient(), TimeStampHolder.class));
 	}
 
-	public Guild(IShard shard, String name, String id, String icon, String ownerID, String afkChannel, int afkTimeout,
+	public Guild(IShard shard, String name, long id, String icon, long ownerID, long afkChannel, int afkTimeout,
 				 String region, int verification, Cache<IRole> roles, Cache<IChannel> channels,
 				 Cache<IVoiceChannel> voiceChannels, Cache<IUser> users, Cache<TimeStampHolder> joinTimes) {
 		this.shard = shard;
@@ -171,7 +171,7 @@ public class Guild implements IGuild {
 	}
 
 	@Override
-	public String getOwnerID() {
+	public long getOwnerLongID() {
 		return ownerID;
 	}
 
@@ -185,7 +185,7 @@ public class Guild implements IGuild {
 	 *
 	 * @param id The user if of the new owner.
 	 */
-	public void setOwnerID(String id) {
+	public void setOwnerID(long id) {
 		ownerID = id;
 	}
 
@@ -225,7 +225,7 @@ public class Guild implements IGuild {
 	}
 
 	@Override
-	public IChannel getChannelByID(String id) {
+	public IChannel getChannelByID(long id) {
 		return channels.get(id);
 	}
 
@@ -235,16 +235,16 @@ public class Guild implements IGuild {
 	}
 
 	@Override
-	public IUser getUserByID(String id) {
-		if (users == null || id == null)
+	public IUser getUserByID(long id) {
+		if (users == null)
 			return null;
 
 		IUser user = users.get(id);
 
 		if (user == null) {
-			if (client.getOurUser() != null && id.equals(client.getOurUser().getID()))
+			if (client.getOurUser() != null && id == client.getOurUser().getLongID())
 				user = client.getOurUser();
-			else if (id.equals(ownerID))
+			else if (id == ownerID)
 				user = getOwner();
 		}
 
@@ -299,7 +299,7 @@ public class Guild implements IGuild {
 	}
 
 	@Override
-	public String getID() {
+	public long getLongID() {
 		return id;
 	}
 
@@ -324,7 +324,7 @@ public class Guild implements IGuild {
 	}
 
 	@Override
-	public IRole getRoleByID(String id) {
+	public IRole getRoleByID(long id) {
 		return roles.get(id);
 	}
 
@@ -351,7 +351,7 @@ public class Guild implements IGuild {
 	}
 
 	@Override
-	public IVoiceChannel getVoiceChannelByID(String id) {
+	public IVoiceChannel getVoiceChannelByID(long id) {
 		return voiceChannels.get(id);
 	}
 
@@ -372,7 +372,7 @@ public class Guild implements IGuild {
 		return afkTimeout;
 	}
 
-	public void setAFKChannel(String id) {
+	public void setAFKChannel(long id) {
 		this.afkChannel = id;
 	}
 
@@ -409,11 +409,11 @@ public class Guild implements IGuild {
 	@Override
 	public void banUser(IUser user, int deleteMessagesForDays) {
 		DiscordUtils.checkPermissions(client, this, getRolesForUser(user), EnumSet.of(Permissions.BAN));
-		banUser(user.getID(), deleteMessagesForDays);
+		banUser(user.getLongID(), deleteMessagesForDays);
 	}
 
 	@Override
-	public void banUser(String userID) {
+	public void banUser(long userID) {
 		IUser user = getUserByID(userID);
 		if (getUserByID(userID) == null) {
 			DiscordUtils.checkPermissions(client, this, EnumSet.of(Permissions.BAN));
@@ -425,20 +425,20 @@ public class Guild implements IGuild {
 	}
 
 	@Override
-	public void banUser(String userID, int deleteMessagesForDays) {
-		((DiscordClientImpl) client).REQUESTS.PUT.makeRequest(DiscordEndpoints.GUILDS + id + "/bans/" + userID + "?delete-message-days=" + deleteMessagesForDays);
+	public void banUser(long userID, int deleteMessagesForDays) {
+		((DiscordClientImpl) client).REQUESTS.PUT.makeRequest(DiscordEndpoints.GUILDS + id + "/bans/" + Long.toUnsignedString(userID) + "?delete-message-days=" + deleteMessagesForDays);
 	}
 
 	@Override
-	public void pardonUser(String userID) {
+	public void pardonUser(long userID) {
 		DiscordUtils.checkPermissions(client, this, EnumSet.of(Permissions.BAN));
-		((DiscordClientImpl) client).REQUESTS.DELETE.makeRequest(DiscordEndpoints.GUILDS+id+"/bans/"+userID);
+		((DiscordClientImpl) client).REQUESTS.DELETE.makeRequest(DiscordEndpoints.GUILDS + id + "/bans/" + Long.toUnsignedString(userID));
 	}
 
 	@Override
 	public void kickUser(IUser user) {
 		DiscordUtils.checkPermissions(client, this, user.getRolesForGuild(this), EnumSet.of(Permissions.KICK));
-		((DiscordClientImpl) client).REQUESTS.DELETE.makeRequest(DiscordEndpoints.GUILDS+id+"/members/"+user.getID());
+		((DiscordClientImpl) client).REQUESTS.DELETE.makeRequest(DiscordEndpoints.GUILDS+id+"/members/"+user.getStringID());
 	}
 
 	@Override
@@ -447,7 +447,7 @@ public class Guild implements IGuild {
 
 		try {
 			((DiscordClientImpl) client).REQUESTS.PATCH.makeRequest(
-					DiscordEndpoints.GUILDS+id+"/members/"+user.getID(),
+					DiscordEndpoints.GUILDS+id+"/members/"+user.getStringID(),
 					DiscordUtils.MAPPER_NO_NULLS.writeValueAsString(new MemberEditRequest.Builder().roles(roles).build()));
 		} catch (JsonProcessingException e) {
 			Discord4J.LOGGER.error(LogMarkers.HANDLE, "Discord4J Internal Exception", e);
@@ -461,7 +461,7 @@ public class Guild implements IGuild {
 
 		try {
 			((DiscordClientImpl) client).REQUESTS.PATCH.makeRequest(
-					DiscordEndpoints.GUILDS+id+"/members/"+user.getID(),
+					DiscordEndpoints.GUILDS+id+"/members/"+user.getStringID(),
 					DiscordUtils.MAPPER_NO_NULLS.writeValueAsString(new MemberEditRequest.Builder().deafen(deafen).build()));
 		} catch (JsonProcessingException e) {
 			Discord4J.LOGGER.error(LogMarkers.HANDLE, "Discord4J Internal Exception", e);
@@ -474,7 +474,7 @@ public class Guild implements IGuild {
 
 		try {
 			((DiscordClientImpl) client).REQUESTS.PATCH.makeRequest(
-					DiscordEndpoints.GUILDS+id+"/members/"+user.getID(),
+					DiscordEndpoints.GUILDS+id+"/members/"+user.getStringID(),
 					DiscordUtils.MAPPER_NO_NULLS.writeValueAsString(new MemberEditRequest.Builder().mute(mute).build()));
 		} catch (JsonProcessingException e) {
 			Discord4J.LOGGER.error(LogMarkers.HANDLE, "Discord4J Internal Exception", e);
@@ -492,7 +492,7 @@ public class Guild implements IGuild {
 
 		try {
 			((DiscordClientImpl) client).REQUESTS.PATCH.makeRequest(
-					DiscordEndpoints.GUILDS+id+"/members/"+(isSelf ? "@me/nick" : user.getID()),
+					DiscordEndpoints.GUILDS+id+"/members/"+(isSelf ? "@me/nick" : user.getStringID()),
 					DiscordUtils.MAPPER_NO_NULLS.writeValueAsString(new MemberEditRequest.Builder().nick(nick == null ? "" : nick).build()));
 		} catch (JsonProcessingException e) {
 			Discord4J.LOGGER.error(LogMarkers.HANDLE, "Discord4J Internal Exception", e);
@@ -518,7 +518,7 @@ public class Guild implements IGuild {
 
 		((DiscordClientImpl) client).REQUESTS.PATCH.makeRequest(
 				DiscordEndpoints.GUILDS + id, new GuildEditRequest(name, region.getID(), level.ordinal(), icon.getData(),
-						afkChannel == null ? null : afkChannel.getID(), afkTimeout));
+						afkChannel == null ? null : afkChannel.getStringID(), afkTimeout));
 	}
 
 	@Override
@@ -554,7 +554,7 @@ public class Guild implements IGuild {
 	@Override
 	@Deprecated
 	public void deleteGuild() {
-		if (!ownerID.equals(client.getOurUser().getID()))
+		if (ownerID != client.getOurUser().getLongID())
 			throw new MissingPermissionsException("You must be the guild owner to delete guilds!", EnumSet.noneOf(Permissions.class));
 
 		((DiscordClientImpl) client).REQUESTS.DELETE.makeRequest(DiscordEndpoints.GUILDS+id);
@@ -563,7 +563,7 @@ public class Guild implements IGuild {
 	@Override
 	@Deprecated
 	public void leaveGuild() {
-		if (ownerID.equals(client.getOurUser().getID()))
+		if (ownerID == client.getOurUser().getLongID())
 			throw new DiscordException("Guild owners cannot leave their own guilds! Use deleteGuild() instead.");
 
 		((DiscordClientImpl) client).REQUESTS.DELETE.makeRequest(DiscordEndpoints.USERS+"@me/guilds/"+id);
@@ -583,7 +583,7 @@ public class Guild implements IGuild {
 			throw new DiscordException("Channel name can only be between 2 and 100 characters!");
 
 		ChannelObject response = ((DiscordClientImpl) client).REQUESTS.POST.makeRequest(
-				DiscordEndpoints.GUILDS+getID()+"/channels",
+				DiscordEndpoints.GUILDS+getStringID()+"/channels",
 				new ChannelCreateRequest(name, "text"),
 				ChannelObject.class);
 
@@ -602,7 +602,7 @@ public class Guild implements IGuild {
 			throw new DiscordException("Channel name can only be between 2 and 100 characters!");
 
 		ChannelObject response = ((DiscordClientImpl) client).REQUESTS.POST.makeRequest(
-				DiscordEndpoints.GUILDS+getID()+"/channels",
+				DiscordEndpoints.GUILDS+getStringID()+"/channels",
 				new ChannelCreateRequest(name, "voice"),
 				ChannelObject.class);
 
@@ -682,11 +682,11 @@ public class Guild implements IGuild {
 			IRole role = rolesInOrder[i];
 
 			int newPosition = role.getPosition();
-			int oldPosition = getRoleByID(role.getID()).getPosition();
+			int oldPosition = getRoleByID(role.getLongID()).getPosition();
 			if (newPosition != oldPosition && oldPosition >= usersHighest) { // If the position was changed and the user doesn't have permission to change it.
 				throw new MissingPermissionsException("Cannot edit the position of a role higher than or equal to your own.", EnumSet.noneOf(Permissions.class));
 			} else {
-				request[i] = new ReorderRolesRequest(role.getID(), i);
+				request[i] = new ReorderRolesRequest(role.getStringID(), i);
 			}
 		}
 
@@ -721,18 +721,18 @@ public class Guild implements IGuild {
 
 	@Override
 	public LocalDateTime getJoinTimeForUser(IUser user) {
-		if (!joinTimes.containsKey(user.getID()))
+		if (!joinTimes.containsKey(user.getLongID()))
 			throw new DiscordException("Cannot find user "+user.getDisplayName(this)+" in this guild!");
 
-		return joinTimes.get(user.getID()).getObject();
+		return joinTimes.get(user.getLongID()).getObject();
 	}
 
 	@Override
-	public IMessage getMessageByID(String id) {
+	public IMessage getMessageByID(long id) {
 		IMessage message =  channels.stream()
 				.map(IChannel::getMessageHistory)
 				.flatMap(List::stream)
-				.filter(msg -> msg.getID().equalsIgnoreCase(id))
+				.filter(msg -> msg.getLongID() == id)
 				.findAny().orElse(null);
 
 		if (message == null) {
@@ -768,7 +768,7 @@ public class Guild implements IGuild {
 	}
 
 	@Override
-	public IEmoji getEmojiByID(String id) {
+	public IEmoji getEmojiByID(long id) {
 		return emojis.get(id);
 	}
 
@@ -780,7 +780,7 @@ public class Guild implements IGuild {
 	}
 
 	@Override
-	public IWebhook getWebhookByID(String id) {
+	public IWebhook getWebhookByID(long id) {
 		return channels.stream()
 				.map(channel -> channel.getWebhookByID(id))
 				.filter(Objects::nonNull)
@@ -819,18 +819,19 @@ public class Guild implements IGuild {
 						.collect(Collectors.toCollection(CopyOnWriteArrayList::new));
 
 				WebhookObject[] response = ((DiscordClientImpl) client).REQUESTS.GET.makeRequest(
-						DiscordEndpoints.GUILDS + getID() + "/webhooks",
+						DiscordEndpoints.GUILDS + getStringID() + "/webhooks",
 						WebhookObject[].class);
 
 				if (response != null) {
 					for (WebhookObject webhookObject : response) {
-						Channel channel = (Channel) getChannelByID(webhookObject.channel_id);
-						if (getWebhookByID(webhookObject.id) == null) {
+						Channel channel = (Channel) getChannelByID(Long.parseUnsignedLong(webhookObject.channel_id));
+						long webhookId = Long.parseUnsignedLong(webhookObject.id);
+						if (getWebhookByID(webhookId) == null) {
 							IWebhook newWebhook = DiscordUtils.getWebhookFromJSON(channel, webhookObject);
 							client.getDispatcher().dispatch(new WebhookCreateEvent(newWebhook));
 							channel.webhooks.put(newWebhook);
 						} else {
-							IWebhook toUpdate = channel.getWebhookByID(webhookObject.id);
+							IWebhook toUpdate = channel.getWebhookByID(webhookId);
 							IWebhook oldWebhook = toUpdate.copy();
 							toUpdate = DiscordUtils.getWebhookFromJSON(channel, webhookObject);
 							if (!oldWebhook.getDefaultName().equals(toUpdate.getDefaultName()) || !String.valueOf(oldWebhook.getDefaultAvatar()).equals(String.valueOf(toUpdate.getDefaultAvatar())))
@@ -878,7 +879,7 @@ public class Guild implements IGuild {
 
 	public static class TimeStampHolder extends IDLinkedObjectWrapper<LocalDateTime> {
 
-		public TimeStampHolder(String id, LocalDateTime obj) {
+		public TimeStampHolder(long id, LocalDateTime obj) {
 			super(id, obj);
 		}
 	}

--- a/src/main/java/sx/blah/discord/handle/impl/obj/Invite.java
+++ b/src/main/java/sx/blah/discord/handle/impl/obj/Invite.java
@@ -51,7 +51,7 @@ public class Invite implements IInvite {
 		client.checkReady("get invite details");
 		InviteObject response = ((DiscordClientImpl) client).REQUESTS.GET.makeRequest(DiscordEndpoints.INVITE+inviteCode, InviteObject.class);
 
-		return new InviteResponse(response.guild.id, response.guild.name, response.channel.id, response.channel.name);
+		return new InviteResponse(Long.parseUnsignedLong(response.guild.id), response.guild.name, Long.parseUnsignedLong(response.channel.id), response.channel.name);
 	}
 
 	@Override

--- a/src/main/java/sx/blah/discord/handle/impl/obj/PrivateChannel.java
+++ b/src/main/java/sx/blah/discord/handle/impl/obj/PrivateChannel.java
@@ -21,6 +21,7 @@ import sx.blah.discord.api.internal.DiscordClientImpl;
 import sx.blah.discord.handle.obj.*;
 import sx.blah.discord.util.Image;
 import sx.blah.discord.util.cache.Cache;
+import sx.blah.discord.util.cache.LongMap;
 
 import java.util.*;
 
@@ -31,7 +32,7 @@ public class PrivateChannel extends Channel implements IPrivateChannel {
 	 */
 	protected final IUser recipient;
 
-	public PrivateChannel(DiscordClientImpl client, IUser recipient, String id) {
+	public PrivateChannel(DiscordClientImpl client, IUser recipient, long id) {
 		super(client, recipient.getName(), id, null, null, 0,
 				new Cache<>(Cache.IGNORING_PROVIDER.provide(PermissionOverride.class)),
 				new Cache<>(Cache.IGNORING_PROVIDER.provide(PermissionOverride.class)));
@@ -39,13 +40,13 @@ public class PrivateChannel extends Channel implements IPrivateChannel {
 	}
 
 	@Override
-	public Map<String, PermissionOverride> getUserOverrides() {
-		return new HashMap<>();
+	public LongMap<PermissionOverride> getUserOverridesLong() {
+		return LongMap.emptyMap();
 	}
 
 	@Override
-	public Map<String, PermissionOverride> getRoleOverrides() {
-		return new HashMap<>();
+	public LongMap<PermissionOverride> getRoleOverridesLong() {
+		return LongMap.emptyMap();
 	}
 
 	@Override
@@ -162,7 +163,7 @@ public class PrivateChannel extends Channel implements IPrivateChannel {
 	}
 
 	@Override
-	public IWebhook getWebhookByID(String id) {
+	public IWebhook getWebhookByID(long id) {
 		throw new UnsupportedOperationException();
 	}
 

--- a/src/main/java/sx/blah/discord/handle/impl/obj/Reaction.java
+++ b/src/main/java/sx/blah/discord/handle/impl/obj/Reaction.java
@@ -89,7 +89,7 @@ public class Reaction implements IReaction {
 
 	@Override
 	public IEmoji getCustomEmoji() {
-		return getMessage().getGuild().getEmojiByID(emoji);
+		return getMessage().getGuild().getEmojiByID(Long.parseUnsignedLong(emoji));
 	}
 
 	@Override
@@ -121,11 +121,11 @@ public class Reaction implements IReaction {
 			users.clear();
 
 			int gottenSoFar = 0;
-			String emoji = isCustomEmoji() ? (getCustomEmoji().getName() + ":" + getCustomEmoji().getID()) : this.emoji;
+			String emoji = isCustomEmoji() ? (getCustomEmoji().getName() + ":" + getCustomEmoji().getStringID()) : this.emoji;
 			String userAfter = null;
 			while (gottenSoFar < count) {
 				ReactionUserObject[] userObjs = ((DiscordClientImpl) getClient()).REQUESTS.GET.makeRequest(
-						String.format(DiscordEndpoints.REACTIONS_USER_LIST, message.getChannel().getID(), message.getID(), emoji),
+						String.format(DiscordEndpoints.REACTIONS_USER_LIST, message.getChannel().getStringID(), message.getStringID(), emoji),
 						ReactionUserObject[].class,
 						new BasicNameValuePair("after", userAfter));
 
@@ -135,7 +135,7 @@ public class Reaction implements IReaction {
 				gottenSoFar += userObjs.length;
 
 				for (ReactionUserObject obj : userObjs) {
-					IUser u = getClient().getUserByID(obj.id);
+					IUser u = getClient().getUserByID(Long.parseUnsignedLong(obj.id));
 
 					if (u != null) {
 						users.add(u);

--- a/src/main/java/sx/blah/discord/handle/impl/obj/Role.java
+++ b/src/main/java/sx/blah/discord/handle/impl/obj/Role.java
@@ -61,7 +61,7 @@ public class Role implements IRole {
 	/**
 	 * The role id
 	 */
-	protected volatile String id;
+	protected volatile long id;
 
 	/**
 	 * Whether to display this role separately from others
@@ -83,7 +83,7 @@ public class Role implements IRole {
 	 */
 	protected volatile IGuild guild;
 
-	public Role(int position, int permissions, String name, boolean managed, String id, boolean hoist, int color, boolean mentionable, IGuild guild) {
+	public Role(int position, int permissions, String name, boolean managed, long id, boolean hoist, int color, boolean mentionable, IGuild guild) {
 		this.position = position;
 		this.permissions = Permissions.getAllowedPermissionsForNumber(permissions);
 		this.name = name;
@@ -143,7 +143,7 @@ public class Role implements IRole {
 	}
 
 	@Override
-	public String getID() {
+	public long getLongID() {
 		return id;
 	}
 
@@ -201,7 +201,7 @@ public class Role implements IRole {
 			DiscordUtils.getRoleFromJSON(guild,
 					DiscordUtils.MAPPER.readValue(
 							((DiscordClientImpl) getClient()).REQUESTS.PATCH.makeRequest(
-									DiscordEndpoints.GUILDS + guild.getID() + "/roles/" + id,
+									DiscordEndpoints.GUILDS + guild.getStringID() + "/roles/" + id,
 									DiscordUtils.MAPPER_NO_NULLS.writeValueAsString(request)), RoleObject.class));
 		} catch (IOException e) {
 			Discord4J.LOGGER.error(LogMarkers.HANDLE, "Discord4J Internal Exception", e);
@@ -258,7 +258,7 @@ public class Role implements IRole {
 	public void delete() {
 		DiscordUtils.checkPermissions(((Guild) guild).client, guild, Collections.singletonList(this), EnumSet.of(Permissions.MANAGE_ROLES));
 
-		((DiscordClientImpl) getClient()).REQUESTS.DELETE.makeRequest(DiscordEndpoints.GUILDS+guild.getID()+"/roles/"+id);
+		((DiscordClientImpl) getClient()).REQUESTS.DELETE.makeRequest(DiscordEndpoints.GUILDS+guild.getStringID()+"/roles/"+id);
 	}
 
 	@Override

--- a/src/main/java/sx/blah/discord/handle/impl/obj/VoiceChannel.java
+++ b/src/main/java/sx/blah/discord/handle/impl/obj/VoiceChannel.java
@@ -40,7 +40,7 @@ public class VoiceChannel extends Channel implements IVoiceChannel {
 	protected volatile int userLimit = 0;
 	protected volatile int bitrate = 0;
 
-	public VoiceChannel(DiscordClientImpl client, String name, String id, IGuild guild, String topic, int position,
+	public VoiceChannel(DiscordClientImpl client, String name, long id, IGuild guild, String topic, int position,
 						int userLimit, int bitrate, Cache<PermissionOverride> userOverrides, Cache<PermissionOverride> roleOverrides) {
 		super(client, name, id, guild, topic, position, roleOverrides, userOverrides);
 		this.userLimit = userLimit;
@@ -123,7 +123,7 @@ public class VoiceChannel extends Channel implements IVoiceChannel {
 		boolean isMuted = voiceState != null && voiceState.isMuted();
 		boolean isDeafened = voiceState != null && voiceState.isDeafened();
 		((ShardImpl) getShard()).ws.send(GatewayOps.VOICE_STATE_UPDATE,
-				new VoiceStateUpdateRequest(getGuild().getID(), getID(), isMuted, isDeafened));
+				new VoiceStateUpdateRequest(getGuild().getStringID(), getStringID(), isMuted, isDeafened));
 	}
 
 	@Override
@@ -136,9 +136,9 @@ public class VoiceChannel extends Channel implements IVoiceChannel {
 		boolean isDeafened = voiceState != null && voiceState.isDeafened();
 
 		((ShardImpl) getShard()).ws.send(GatewayOps.VOICE_STATE_UPDATE,
-				new VoiceStateUpdateRequest(getGuild().getID(), null, isMuted, isDeafened));
+				new VoiceStateUpdateRequest(getGuild().getStringID(), null, isMuted, isDeafened));
 
-		DiscordVoiceWS vWS = ((ShardImpl) getShard()).voiceWebSockets.get(getGuild().getID());
+		DiscordVoiceWS vWS = ((ShardImpl) getShard()).voiceWebSockets.get(getGuild().getLongID());
 		if (vWS != null) {
 			vWS.disconnect(VoiceDisconnectedEvent.Reason.LEFT_CHANNEL);
 		}
@@ -170,17 +170,17 @@ public class VoiceChannel extends Channel implements IVoiceChannel {
 	}
 
 	@Override
-	public MessageHistory getMessageHistoryFrom(String id, int maxCount) {
+	public MessageHistory getMessageHistoryFrom(long id, int maxCount) {
 		throw new UnsupportedOperationException();
 	}
 
 	@Override
-	public MessageHistory getMessageHistoryTo(String id, int maxCount) {
+	public MessageHistory getMessageHistoryTo(long id, int maxCount) {
 		throw new UnsupportedOperationException();
 	}
 
 	@Override
-	public MessageHistory getMessageHistoryIn(String beginID, String endID, int maxCount) {
+	public MessageHistory getMessageHistoryIn(long beginID, long endID, int maxCount) {
 		throw new UnsupportedOperationException();
 	}
 
@@ -210,17 +210,17 @@ public class VoiceChannel extends Channel implements IVoiceChannel {
 	}
 
 	@Override
-	public MessageHistory getMessageHistoryFrom(String id) {
+	public MessageHistory getMessageHistoryFrom(long id) {
 		throw new UnsupportedOperationException();
 	}
 
 	@Override
-	public MessageHistory getMessageHistoryTo(String id) {
+	public MessageHistory getMessageHistoryTo(long id) {
 		throw new UnsupportedOperationException();
 	}
 
 	@Override
-	public MessageHistory getMessageHistoryIn(String beginID, String endID) {
+	public MessageHistory getMessageHistoryIn(long beginID, long endID) {
 		throw new UnsupportedOperationException();
 	}
 
@@ -250,7 +250,7 @@ public class VoiceChannel extends Channel implements IVoiceChannel {
 	}
 
 	@Override
-	public IMessage getMessageByID(String messageID) {
+	public IMessage getMessageByID(long messageID) {
 		return null;
 	}
 
@@ -320,7 +320,7 @@ public class VoiceChannel extends Channel implements IVoiceChannel {
 	}
 
 	@Override
-	public IWebhook getWebhookByID(String id) {
+	public IWebhook getWebhookByID(long id) {
 		throw new UnsupportedOperationException();
 	}
 
@@ -371,6 +371,6 @@ public class VoiceChannel extends Channel implements IVoiceChannel {
 
 	@Override
 	public boolean isDeleted() {
-		return getGuild().getVoiceChannelByID(getID()) != this;
+		return getGuild().getVoiceChannelByID(getLongID()) != this;
 	}
 }

--- a/src/main/java/sx/blah/discord/handle/impl/obj/Webhook.java
+++ b/src/main/java/sx/blah/discord/handle/impl/obj/Webhook.java
@@ -33,7 +33,7 @@ import java.util.Objects;
 
 public class Webhook implements IWebhook {
 
-	protected final String id;
+	protected final long id;
 	protected final IDiscordClient client;
 	protected final IChannel channel;
 	protected final IUser author;
@@ -41,7 +41,7 @@ public class Webhook implements IWebhook {
 	protected volatile String avatar;
 	protected final String token;
 
-	public Webhook(IDiscordClient client, String name, String id, IChannel channel, IUser author, String avatar, String token) {
+	public Webhook(IDiscordClient client, String name, long id, IChannel channel, IUser author, String avatar, String token) {
 		this.client = client;
 		this.name = name;
 		this.id = id;
@@ -52,7 +52,7 @@ public class Webhook implements IWebhook {
 	}
 
 	@Override
-	public String getID() {
+	public long getLongID() {
 		return id;
 	}
 

--- a/src/main/java/sx/blah/discord/handle/obj/IChannel.java
+++ b/src/main/java/sx/blah/discord/handle/obj/IChannel.java
@@ -20,12 +20,14 @@ package sx.blah.discord.handle.obj;
 import sx.blah.discord.api.internal.json.objects.EmbedObject;
 import sx.blah.discord.handle.impl.obj.PrivateChannel;
 import sx.blah.discord.util.*;
+import sx.blah.discord.util.cache.LongMap;
 
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.InputStream;
 import java.time.LocalDateTime;
 import java.util.EnumSet;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -139,8 +141,37 @@ public interface IChannel extends IDiscordObject<IChannel> {
 	 *
 	 * @param id The id to start gathering messages from (inclusive).
 	 * @return The messages.
+	 * @deprecated Use {@link #getMessageHistoryFrom(long)} instead
 	 */
-	MessageHistory getMessageHistoryFrom(String id);
+	@Deprecated
+	default MessageHistory getMessageHistoryFrom(String id) {
+		return getMessageHistoryFrom(Long.parseUnsignedLong(id));
+	}
+
+	/**
+	 * Gets the messages from a specified message id to the beginning of this channel.
+	 * NOTE: This can block the current thread if messages need to be requested from Discord instead of fetched from
+	 * the internal cache.
+	 *
+	 * @param id The id to start gathering messages from (inclusive).
+	 * @return The messages.
+	 */
+	MessageHistory getMessageHistoryFrom(long id);
+
+	/**
+	 * Gets the messages from a specified message id to the beginning of this channel.
+	 * NOTE: This can block the current thread if messages need to be requested from Discord instead of fetched from
+	 * the internal cache.
+	 *
+	 * @param id The id to start gathering messages from (inclusive).
+	 * @param maxMessageCount The max number of messages to retrieve.
+	 * @return The messages.
+	 * @deprecated Use {@link #getMessageHistoryFrom(long, int)} instead
+	 */
+	@Deprecated
+	default MessageHistory getMessageHistoryFrom(String id, int maxMessageCount) {
+		return getMessageHistoryFrom(Long.parseUnsignedLong(id), maxMessageCount);
+	}
 
 	/**
 	 * Gets the messages from a specified message id to the beginning of this channel.
@@ -151,7 +182,21 @@ public interface IChannel extends IDiscordObject<IChannel> {
 	 * @param maxMessageCount The max number of messages to retrieve.
 	 * @return The messages.
 	 */
-	MessageHistory getMessageHistoryFrom(String id, int maxMessageCount);
+	MessageHistory getMessageHistoryFrom(long id, int maxMessageCount);
+
+	/**
+	 * Gets the messages from now up until the specified message id.
+	 * NOTE: This can block the current thread if messages need to be requested from Discord instead of fetched from
+	 * the internal cache.
+	 *
+	 * @param id The id to stop gathering messages at (inclusive).
+	 * @return The messages.
+	 * @deprecated Use {@link #getMessageHistoryTo(long)} instead
+	 */
+	@Deprecated
+	default MessageHistory getMessageHistoryTo(String id) {
+		return getMessageHistoryTo(Long.parseUnsignedLong(id));
+	}
 
 	/**
 	 * Gets the messages from now up until the specified message id.
@@ -161,7 +206,22 @@ public interface IChannel extends IDiscordObject<IChannel> {
 	 * @param id The id to stop gathering messages at (inclusive).
 	 * @return The messages.
 	 */
-	MessageHistory getMessageHistoryTo(String id);
+	MessageHistory getMessageHistoryTo(long id);
+
+	/**
+	 * Gets the messages from now up until the specified message id.
+	 * NOTE: This can block the current thread if messages need to be requested from Discord instead of fetched from
+	 * the internal cache.
+	 *
+	 * @param id The id to stop gathering messages at (inclusive).
+	 * @param maxMessageCount The max number of messages to retrieve.
+	 * @return The messages.
+	 * @deprecated Use {@link #getMessageHistoryTo(long, int)} instead
+	 */
+	@Deprecated
+	default MessageHistory getMessageHistoryTo(String id, int maxMessageCount) {
+		return getMessageHistoryTo(Long.parseUnsignedLong(id), maxMessageCount);
+	}
 
 	/**
 	 * Gets the messages from now up until the specified message id.
@@ -172,7 +232,22 @@ public interface IChannel extends IDiscordObject<IChannel> {
 	 * @param maxMessageCount The max number of messages to retrieve.
 	 * @return The messages.
 	 */
-	MessageHistory getMessageHistoryTo(String id, int maxMessageCount);
+	MessageHistory getMessageHistoryTo(long id, int maxMessageCount);
+
+	/**
+	 * Gets the messages in the specified range of message ids.
+	 * NOTE: This can block the current thread if messages need to be requested from Discord instead of fetched from
+	 * the internal cache.
+	 *
+	 * @param beginID The id to start gathering messages from (inclusive).
+	 * @param endID The id to stop gathering messages at (inclusive).
+	 * @return The messages.
+	 * @deprecated Use {@link #getMessageHistoryIn(long, long)} instead
+	 */
+	@Deprecated
+	default MessageHistory getMessageHistoryIn(String beginID, String endID) {
+		return getMessageHistoryIn(Long.parseUnsignedLong(beginID), Long.parseUnsignedLong(endID));
+	}
 
 	/**
 	 * Gets the messages in the specified range of message ids.
@@ -183,7 +258,23 @@ public interface IChannel extends IDiscordObject<IChannel> {
 	 * @param endID The id to stop gathering messages at (inclusive).
 	 * @return The messages.
 	 */
-	MessageHistory getMessageHistoryIn(String beginID, String endID);
+	MessageHistory getMessageHistoryIn(long beginID, long endID);
+
+	/**
+	 * Gets the messages in the specified range of message ids.
+	 * NOTE: This can block the current thread if messages need to be requested from Discord instead of fetched from
+	 * the internal cache.
+	 *
+	 * @param beginID The id to start gathering messages from (inclusive).
+	 * @param endID The id to stop gathering messages at (inclusive).
+	 * @param maxMessageCount The max number of messages to retrieve.
+	 * @return The messages.
+	 * @deprecated Use {@link #getMessageHistoryIn(long, long, int)} instead
+	 */
+	@Deprecated
+	default MessageHistory getMessageHistoryIn(String beginID, String endID, int maxMessageCount) {
+		return getMessageHistoryIn(Long.parseUnsignedLong(beginID), Long.parseUnsignedLong(endID), maxMessageCount);
+	}
 
 	/**
 	 * Gets the messages in the specified range of message ids.
@@ -195,7 +286,7 @@ public interface IChannel extends IDiscordObject<IChannel> {
 	 * @param maxMessageCount The max number of messages to retrieve.
 	 * @return The messages.
 	 */
-	MessageHistory getMessageHistoryIn(String beginID, String endID, int maxMessageCount);
+	MessageHistory getMessageHistoryIn(long beginID, long endID, int maxMessageCount);
 
 	/**
 	 * This attempts to get ALL messages in the channel.
@@ -248,8 +339,21 @@ public interface IChannel extends IDiscordObject<IChannel> {
 	 *
 	 * @param messageID The message id.
 	 * @return The message (if found).
+	 * @deprecated Use {@link #getMessageByID(long)} instead
 	 */
-	IMessage getMessageByID(String messageID);
+	@Deprecated
+	default IMessage getMessageByID(String messageID) {
+		if (messageID == null) return null;
+		return getMessageByID(Long.parseUnsignedLong(messageID));
+	}
+
+	/**
+	 * Gets a specific message by its id.
+	 *
+	 * @param messageID The message id.
+	 * @return The message (if found).
+	 */
+	IMessage getMessageByID(long messageID);
 
 	/**
 	 * Gets the guild this channel is a part of.
@@ -685,15 +789,41 @@ public interface IChannel extends IDiscordObject<IChannel> {
 	 * Gets the permissions overrides for users. (Key = User id).
 	 *
 	 * @return The user permissions overrides for this channel.
+	 * @deprecated Use {@link #getUserOverridesLong()} instead
 	 */
-	Map<String, PermissionOverride> getUserOverrides();
+	@Deprecated
+	default Map<String, PermissionOverride> getUserOverrides() {
+		Map<String, PermissionOverride> map = new HashMap<>();
+		getUserOverridesLong().forEach((key, value)-> map.put(Long.toUnsignedString(key), value));
+		return map;
+	}
+
+	/**
+	 * Gets the permissions overrides for users. (Key = User id).
+	 *
+	 * @return The user permissions overrides for this channel.
+	 */
+	LongMap<PermissionOverride> getUserOverridesLong();
+
+	/**
+	 * Gets the permissions overrides for roles. (Key = Role id).
+	 *
+	 * @return The role permissions overrides for this channel.
+	 * @deprecated Use {@link #getRoleOverridesLong()} instead
+	 */
+	@Deprecated
+	default Map<String, PermissionOverride> getRoleOverrides() {
+		Map<String, PermissionOverride> map = new HashMap<>();
+		getRoleOverridesLong().forEach((key, value)-> map.put(Long.toUnsignedString(key), value));
+		return map;
+	}
 
 	/**
 	 * Gets the permissions overrides for roles. (Key = Role id).
 	 *
 	 * @return The role permissions overrides for this channel.
 	 */
-	Map<String, PermissionOverride> getRoleOverrides();
+	LongMap<PermissionOverride> getRoleOverridesLong();
 
 	/**
 	 * Gets the permissions available for a user with all permission overrides taken into account.
@@ -821,8 +951,21 @@ public interface IChannel extends IDiscordObject<IChannel> {
 	 *
 	 * @param id The webhook id.
 	 * @return The webhook or null if not found.
+	 * @deprecated Use {@link #getWebhookByID(long)} instead
 	 */
-	IWebhook getWebhookByID(String id);
+	@Deprecated
+	default IWebhook getWebhookByID(String id) {
+		if (id == null) return null;
+		return getWebhookByID(Long.parseUnsignedLong(id));
+	}
+
+	/**
+	 * This gets a webhook by its id.
+	 *
+	 * @param id The webhook id.
+	 * @return The webhook or null if not found.
+	 */
+	IWebhook getWebhookByID(long id);
 
 	/**
 	 * This finds all the webhooks which have the same name as the provided one.
@@ -883,9 +1026,9 @@ public interface IChannel extends IDiscordObject<IChannel> {
 		/**
 		 * The id of the object this is linked to.
 		 */
-		protected final String id;
+		protected final long id;
 
-		public PermissionOverride(EnumSet<Permissions> allow, EnumSet<Permissions> deny, String id) {
+		public PermissionOverride(EnumSet<Permissions> allow, EnumSet<Permissions> deny, long id) {
 			this.allow = allow;
 			this.deny = deny;
 			this.id = id;
@@ -929,7 +1072,7 @@ public interface IChannel extends IDiscordObject<IChannel> {
 		}
 
 		@Override
-		public String getID() {
+		public long getLongID() {
 			return id;
 		}
 	}

--- a/src/main/java/sx/blah/discord/handle/obj/IDiscordObject.java
+++ b/src/main/java/sx/blah/discord/handle/obj/IDiscordObject.java
@@ -47,7 +47,7 @@ public interface IDiscordObject<SELF extends IDiscordObject<SELF>> extends IIDLi
 	 * @return The creation date of this object.
 	 */
 	default LocalDateTime getCreationDate() {
-		return DiscordUtils.getSnowflakeTimeFromID(getID());
+		return DiscordUtils.getSnowflakeTimeFromID(getLongID());
 	}
 
 	/**

--- a/src/main/java/sx/blah/discord/handle/obj/IGuild.java
+++ b/src/main/java/sx/blah/discord/handle/obj/IGuild.java
@@ -36,8 +36,19 @@ public interface IGuild extends IDiscordObject<IGuild> {
 	 * Gets the user id for the owner of this guild.
 	 *
 	 * @return The owner id.
+	 * @deprecated Use {@link #getOwnerLongID()}
 	 */
-	String getOwnerID();
+	@Deprecated
+	default String getOwnerID() {
+		return Long.toUnsignedString(getOwnerLongID());
+	}
+
+	/**
+	 * Gets the user id for the owner of this guild.
+	 *
+	 * @return The owner id.
+	 */
+	long getOwnerLongID();
 
 	/**
 	 * Gets the user object for the owner of this guild.
@@ -72,8 +83,21 @@ public interface IGuild extends IDiscordObject<IGuild> {
 	 *
 	 * @param id The ID of the channel you want to find.
 	 * @return The channel with given ID.
+	 * @deprecated Use {@link #getChannelByID(long)} instead
 	 */
-	IChannel getChannelByID(String id);
+	@Deprecated
+	default IChannel getChannelByID(String id) {
+		if (id == null) return null;
+		return getChannelByID(Long.parseUnsignedLong(id));
+	}
+
+	/**
+	 * Gets a channel on the guild by a specific channel id.
+	 *
+	 * @param id The ID of the channel you want to find.
+	 * @return The channel with given ID.
+	 */
+	IChannel getChannelByID(long id);
 
 	/**
 	 * Gets all the users connected to the guild.
@@ -87,8 +111,21 @@ public interface IGuild extends IDiscordObject<IGuild> {
 	 *
 	 * @param id ID of the user you want to find.
 	 * @return The user with given ID.
+	 * @deprecated Use {@link #getUserByID(long)} instead
 	 */
-	IUser getUserByID(String id);
+	@Deprecated
+	default IUser getUserByID(String id) {
+		if (id == null) return null;
+		return getUserByID(Long.parseUnsignedLong(id));
+	}
+
+	/**
+	 * Gets a user by its id in the guild.
+	 *
+	 * @param id ID of the user you want to find.
+	 * @return The user with given ID.
+	 */
+	IUser getUserByID(long id);
 
 	/**
 	 * Gets all the channels which has a name matching the provided one.
@@ -160,8 +197,21 @@ public interface IGuild extends IDiscordObject<IGuild> {
 	 *
 	 * @param id The role id of the desired role.
 	 * @return The role, or null if not found.
+	 * @deprecated Use {@link #getRoleByID(long)} instead
 	 */
-	IRole getRoleByID(String id);
+	@Deprecated
+	default IRole getRoleByID(String id) {
+		if (id == null) return null;
+		return getRoleByID(Long.parseUnsignedLong(id));
+	}
+
+	/**
+	 * Gets a role object for its unique id.
+	 *
+	 * @param id The role id of the desired role.
+	 * @return The role, or null if not found.
+	 */
+	IRole getRoleByID(long id);
 
 	/**
 	 * This finds all the roles which has the same name as the provided one.
@@ -183,8 +233,21 @@ public interface IGuild extends IDiscordObject<IGuild> {
 	 *
 	 * @param id The channel id.
 	 * @return The voice channel (or null if not found).
+	 * @deprecated Use {@link #getVoiceChannelByID(long)} instead
 	 */
-	IVoiceChannel getVoiceChannelByID(String id);
+	@Deprecated
+	default IVoiceChannel getVoiceChannelByID(String id) {
+		if (id == null) return null;
+		return getVoiceChannelByID(Long.parseUnsignedLong(id));
+	}
+
+	/**
+	 * Gets a voice channel for a give id.
+	 *
+	 * @param id The channel id.
+	 * @return The voice channel (or null if not found).
+	 */
+	IVoiceChannel getVoiceChannelByID(long id);
 
 	/**
 	 * Gets the voice channel that the bot is currently connected to.
@@ -259,8 +322,41 @@ public interface IGuild extends IDiscordObject<IGuild> {
 	 * @throws MissingPermissionsException
 	 * @throws RateLimitException
 	 * @throws DiscordException
+	 * @deprecated Use {@link #banUser(long)} instead
 	 */
-	void banUser(String userID);
+	@Deprecated
+	default void banUser(String userID) {
+		if (userID == null) return;
+		banUser(Long.parseUnsignedLong(userID));
+	}
+
+	/**
+	 * Bans a user from this guild.
+	 *
+	 * @param userID The snowflake ID of the user.
+	 *
+	 * @throws MissingPermissionsException
+	 * @throws RateLimitException
+	 * @throws DiscordException
+	 */
+	void banUser(long userID);
+
+	/**
+	 * Bans a user from this guild.
+	 *
+	 * @param userID The snowflake ID of the user.
+	 * @param deleteMessagesForDays The number of days to delete messages from this user for.
+	 *
+	 * @throws MissingPermissionsException
+	 * @throws RateLimitException
+	 * @throws DiscordException
+	 * @deprecated Use {@link #banUser(long, int)} instead
+	 */
+	@Deprecated
+	default void banUser(String userID, int deleteMessagesForDays) {
+		if (userID == null) return;
+		banUser(Long.parseUnsignedLong(userID), deleteMessagesForDays);
+	}
 
 	/**
 	 * Bans a user from this guild.
@@ -272,7 +368,23 @@ public interface IGuild extends IDiscordObject<IGuild> {
 	 * @throws RateLimitException
 	 * @throws DiscordException
 	 */
-	void banUser(String userID, int deleteMessagesForDays);
+	void banUser(long userID, int deleteMessagesForDays);
+
+	/**
+	 * This removes a ban on a user.
+	 *
+	 * @param userID The user to unban.
+	 *
+	 * @throws MissingPermissionsException
+	 * @throws RateLimitException
+	 * @throws DiscordException
+	 * @deprecated Use {@link #pardonUser(long)} instead
+	 */
+	@Deprecated
+	default void pardonUser(String userID) {
+		if (userID == null) return;
+		pardonUser(Long.parseUnsignedLong(userID));
+	}
 
 	/**
 	 * This removes a ban on a user.
@@ -283,7 +395,7 @@ public interface IGuild extends IDiscordObject<IGuild> {
 	 * @throws RateLimitException
 	 * @throws DiscordException
 	 */
-	void pardonUser(String userID);
+	void pardonUser(long userID);
 
 	/**
 	 * Kicks a user from the guild.
@@ -578,8 +690,21 @@ public interface IGuild extends IDiscordObject<IGuild> {
 	 *
 	 * @param id The message id.
 	 * @return The message or null if not found.
+	 * @deprecated Use {@link #getMessageByID(long)} instad
 	 */
-	IMessage getMessageByID(String id);
+	@Deprecated
+	default IMessage getMessageByID(String id) {
+		if (id == null) return null;
+		return getMessageByID(Long.parseUnsignedLong(id));
+	}
+
+	/**
+	 * This gets a message by its id.
+	 *
+	 * @param id The message id.
+	 * @return The message or null if not found.
+	 */
+	IMessage getMessageByID(long id);
 
 	/**
 	 * This gets all the emojis in the guild.
@@ -593,8 +718,21 @@ public interface IGuild extends IDiscordObject<IGuild> {
 	 *
 	 * @param id The ID.
 	 * @return The emoji.
+	 * @deprecated Use {@link #getEmojiByID(long)} instead
 	 */
-	IEmoji getEmojiByID(String id);
+	@Deprecated
+	default IEmoji getEmojiByID(String id) {
+		if (id == null) return null;
+		return getEmojiByID(Long.parseUnsignedLong(id));
+	}
+
+	/**
+	 * This gets an emoji by its ID.
+	 *
+	 * @param id The ID.
+	 * @return The emoji.
+	 */
+	IEmoji getEmojiByID(long id);
 
 	/**
 	 * This gets an emoji by its name.
@@ -609,8 +747,21 @@ public interface IGuild extends IDiscordObject<IGuild> {
 	 *
 	 * @param id The webhook id.
 	 * @return The webhook or null if not found.
+	 * @deprecated Use {@link #getWebhookByID(long)} instead
 	 */
-	IWebhook getWebhookByID(String id);
+	@Deprecated
+	default IWebhook getWebhookByID(String id) {
+		if (id == null) return null;
+		return getWebhookByID(Long.parseUnsignedLong(id));
+	}
+
+	/**
+	 * This gets a webhook by its id.
+	 *
+	 * @param id The webhook id.
+	 * @return The webhook or null if not found.
+	 */
+	IWebhook getWebhookByID(long id);
 
 	/**
 	 * This finds all the webhooks which have the same name as the provided one.

--- a/src/main/java/sx/blah/discord/handle/obj/IIDLinkedObject.java
+++ b/src/main/java/sx/blah/discord/handle/obj/IIDLinkedObject.java
@@ -29,16 +29,16 @@ public interface IIDLinkedObject {
 	 * @deprecated Use {@link #getStringID()} instead as this will return a long in future versions.
 	 */
 	@Deprecated
-	String getID();
+	default String getID() {
+		return getStringID();
+	}
 
 	/**
 	 * Gets the <b>unsigned</b> long value of the id for this object.
 	 *
 	 * @return The id.
 	 */
-	default long getLongID() {
-		return Long.parseUnsignedLong(getID());
-	}
+	long getLongID();
 
 	/**
 	 * Gets the snowflake unique id for this object.
@@ -46,6 +46,6 @@ public interface IIDLinkedObject {
 	 * @return The id.
 	 */
 	default String getStringID() {
-		return getID();
+		return Long.toUnsignedString(getLongID());
 	}
 }

--- a/src/main/java/sx/blah/discord/handle/obj/IInvite.java
+++ b/src/main/java/sx/blah/discord/handle/obj/IInvite.java
@@ -65,7 +65,7 @@ public interface IInvite {
 		/**
 		 * ID of the guild you were invited to.
 		 */
-		private final String guildID;
+		private final long guildID;
 
 		/**
 		 * Name of the guild you were invited to.
@@ -75,7 +75,7 @@ public interface IInvite {
 		/**
 		 * ID of the channel you were invited from.
 		 */
-		private final String channelID;
+		private final long channelID;
 
 		/**
 		 * Name of the channel you were invited from.
@@ -83,7 +83,7 @@ public interface IInvite {
 		private final String channelName;
 
 		//TODO replace with objects. Need to figure out logistics, as the GUILD_CREATE is sent after MESSAGE_CREATE and after we accept the invite
-		public InviteResponse(String guildID, String guildName, String channelID, String channelName) {
+		public InviteResponse(long guildID, String guildName, long channelID, String channelName) {
 			this.guildID = guildID;
 			this.guildName = guildName;
 			this.channelID = channelID;
@@ -94,8 +94,19 @@ public interface IInvite {
 		 * Gets the guild id the invite leads to.
 		 *
 		 * @return The guild id.
+		 * @deprecated Use {@link #getGuildLongID()} instead
 		 */
+		@Deprecated
 		public String getGuildID() {
+			return Long.toUnsignedString(getGuildLongID());
+		}
+
+		/**
+		 * Gets the guild id the invite leads to.
+		 *
+		 * @return The guild id.
+		 */
+		public long getGuildLongID() {
 			return guildID;
 		}
 
@@ -112,8 +123,19 @@ public interface IInvite {
 		 * Gets the channel id the invite leads to.
 		 *
 		 * @return The channel id.
+		 * @deprecated Use {@link #getChannelLongID()} instead
 		 */
+		@Deprecated
 		public String getChannelID() {
+			return Long.toUnsignedString(getChannelLongID());
+		}
+
+		/**
+		 * Gets the channel id the invite leads to.
+		 *
+		 * @return The channel id.
+		 */
+		public long getChannelLongID() {
 			return channelID;
 		}
 

--- a/src/main/java/sx/blah/discord/handle/obj/IMessage.java
+++ b/src/main/java/sx/blah/discord/handle/obj/IMessage.java
@@ -352,13 +352,24 @@ public interface IMessage extends IDiscordObject<IMessage> {
 	 * Gets the ID of the webhook that sent this message. May be null.
 	 *
 	 * @return The webhook ID.
+	 * @deprecated Use {@link #getWebhookLongID()} instead
 	 */
-	String getWebhookID();
+	@Deprecated
+	default String getWebhookID() {
+		return Long.toUnsignedString(getWebhookLongID());
+	}
+
+	/**
+	 * Gets the ID of the webhook that sent this message. May be null.
+	 *
+	 * @return The webhook ID.
+	 */
+	long getWebhookLongID();
 
 	/**
 	 * Represents an attachment included in the message.
 	 */
-	class Attachment {
+	class Attachment implements IIDLinkedObject {
 
 		/**
 		 * The file name of the attachment.
@@ -373,14 +384,14 @@ public interface IMessage extends IDiscordObject<IMessage> {
 		/**
 		 * The attachment id.
 		 */
-		protected final String id;
+		protected final long id;
 
 		/**
 		 * The download link for the attachment.
 		 */
 		protected final String url;
 
-		public Attachment(String filename, int filesize, String id, String url) {
+		public Attachment(String filename, int filesize, long id, String url) {
 			this.filename = filename;
 			this.filesize = filesize;
 			this.id = id;
@@ -409,8 +420,20 @@ public interface IMessage extends IDiscordObject<IMessage> {
 		 * Gets the id of the attachment.
 		 *
 		 * @return The attachment id.
+		 * @deprecated Use {@link #getLongID()} or {@link #getStringID()} instead
 		 */
+		@Deprecated
 		public String getId() {
+			return getStringID();
+		}
+
+		/**
+		 * Gets the id of the attachment.
+		 *
+		 * @return The attachment id.
+		 */
+		@Override
+		public long getLongID() {
 			return id;
 		}
 

--- a/src/main/java/sx/blah/discord/handle/obj/IUser.java
+++ b/src/main/java/sx/blah/discord/handle/obj/IUser.java
@@ -20,8 +20,10 @@ package sx.blah.discord.handle.obj;
 import sx.blah.discord.util.DiscordException;
 import sx.blah.discord.util.MissingPermissionsException;
 import sx.blah.discord.util.RateLimitException;
+import sx.blah.discord.util.cache.LongMap;
 
 import java.util.EnumSet;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -136,8 +138,22 @@ public interface IUser extends IDiscordObject<IUser> {
 	 * Key is the guild ID that the voice state is for.
 	 *
 	 * @return All of the user's voice states.
+	 * @deprecated Use {@link #getVoiceStatesLong()} instead
 	 */
-	Map<String, IVoiceState> getVoiceStates();
+	@Deprecated
+	default Map<String, IVoiceState> getVoiceStates() {
+		Map<String, IVoiceState> map = new HashMap<>();
+		getVoiceStatesLong().forEach((key, value) -> map.put(Long.toUnsignedString(key), value));
+		return map;
+	}
+
+	/**
+	 * Gets all of the user's voice states.
+	 * Key is the guild ID that the voice state is for.
+	 *
+	 * @return All of the user's voice states.
+	 */
+	LongMap<IVoiceState> getVoiceStatesLong();
 
 	/**
 	 * Moves the user to the given voice channel.

--- a/src/main/java/sx/blah/discord/handle/obj/IVoiceState.java
+++ b/src/main/java/sx/blah/discord/handle/obj/IVoiceState.java
@@ -85,7 +85,7 @@ public interface IVoiceState extends IIDLinkedObject {
 	 * @return The guild id.
 	 */
 	@Override
-	default String getID() {
-		return getGuild().getID();
+	default long getLongID() {
+		return getGuild().getLongID();
 	}
 }

--- a/src/main/java/sx/blah/discord/util/BotInviteBuilder.java
+++ b/src/main/java/sx/blah/discord/util/BotInviteBuilder.java
@@ -84,7 +84,7 @@ public class BotInviteBuilder {
 			url += "&permissions="+Permissions.generatePermissionsNumber(permissions);
 
 		if (guild != null)
-			url += "&guild_id="+guild.getID();
+			url += "&guild_id="+guild.getStringID();
 
 		try {
 			return String.format(url, clientIDOverride == null ? client.getApplicationClientID() : clientIDOverride);

--- a/src/main/java/sx/blah/discord/util/IDLinkedObjectWrapper.java
+++ b/src/main/java/sx/blah/discord/util/IDLinkedObjectWrapper.java
@@ -24,10 +24,10 @@ import sx.blah.discord.handle.obj.IIDLinkedObject;
  */
 public class IDLinkedObjectWrapper<T> implements IIDLinkedObject {
 
-	private final String id;
+	private final long id;
 	private final T obj;
 
-	public IDLinkedObjectWrapper(String id, T obj) {
+	public IDLinkedObjectWrapper(long id, T obj) {
 		this.id = id;
 		this.obj = obj;
 	}
@@ -36,7 +36,7 @@ public class IDLinkedObjectWrapper<T> implements IIDLinkedObject {
 	 * {@inheritDoc}
 	 */
 	@Override
-	public String getID() {
+	public long getLongID() {
 		return id;
 	}
 

--- a/src/main/java/sx/blah/discord/util/MessageBuilder.java
+++ b/src/main/java/sx/blah/discord/util/MessageBuilder.java
@@ -104,8 +104,20 @@ public class MessageBuilder {
 	 *
 	 * @param channelID The channel to send the message to.
 	 * @return The message builder instance.
+	 * @deprecated Use {@link #withChannel(long)} instead
 	 */
+	@Deprecated
 	public MessageBuilder withChannel(String channelID) {
+		return withChannel(Long.parseUnsignedLong(channelID));
+	}
+
+	/**
+	 * Sets the channel that the message should go to.
+	 *
+	 * @param channelID The channel to send the message to.
+	 * @return The message builder instance.
+	 */
+	public MessageBuilder withChannel(long channelID) {
 		this.channel = client.getChannelByID(channelID);
 		return this;
 	}

--- a/src/main/java/sx/blah/discord/util/MessageHistory.java
+++ b/src/main/java/sx/blah/discord/util/MessageHistory.java
@@ -101,10 +101,23 @@ public class MessageHistory extends AbstractList<IMessage> implements List<IMess
 	 *
 	 * @param id The id.
 	 * @return The message if found, else null.
+	 * @deprecated Use {@link #get(long)} instead
 	 */
+	@Deprecated
 	public IMessage get(String id) {
+		if (id == null) return null;
+		return get(Long.parseUnsignedLong(id));
+	}
+
+	/**
+	 * This gets a message by its id.
+	 *
+	 * @param id The id.
+	 * @return The message if found, else null.
+	 */
+	public IMessage get(long id) {
 		return Arrays.stream(backing)
-				.filter(msg -> msg.getID().equals(id))
+				.filter(msg -> msg.getLongID() == id)
 				.findFirst()
 				.orElse(null);
 	}
@@ -114,10 +127,17 @@ public class MessageHistory extends AbstractList<IMessage> implements List<IMess
 	 *
 	 * @param id The id to look for.
 	 * @return True if the specified id is stored, false otherwise.
+	 * @deprecated Use {@link #contains(long)} instead
 	 */
+	@Deprecated
 	public boolean contains(String id) {
+		if (id == null) return false;
+		return contains(Long.parseUnsignedLong(id));
+	}
+
+	public boolean contains(long id) {
 		return Arrays.stream(backing)
-				.filter(msg -> msg.getID().equals(id))
+				.filter(msg -> msg.getLongID() == id)
 				.count() > 0;
 	}
 
@@ -206,8 +226,26 @@ public class MessageHistory extends AbstractList<IMessage> implements List<IMess
 	 * @throws DiscordException
 	 * @throws RateLimitException
 	 * @throws MissingPermissionsException
+	 * @deprecated Use {@link #delete(long)} instead
 	 */
+	@Deprecated
 	public IMessage delete(String id) {
+		if (id == null) return null;
+		return delete(Long.parseUnsignedLong(id));
+	}
+
+	/**
+	 * This deletes the message with the specified id This does NOT remove the deleted message from thi MessageHistory
+	 * instance.
+	 *
+	 * @param id The id of the message to delete.
+	 * @return The message deleted or null if the message couldn't be found.
+	 *
+	 * @throws DiscordException
+	 * @throws RateLimitException
+	 * @throws MissingPermissionsException
+	 */
+	public IMessage delete(long id) {
 		IMessage message = get(id);
 
 		if (message == null)

--- a/src/main/java/sx/blah/discord/util/MessageList.java
+++ b/src/main/java/sx/blah/discord/util/MessageList.java
@@ -183,11 +183,11 @@ public class MessageList extends AbstractList<IMessage> implements List<IMessage
 
 		String queryParams = "?limit="+messageCount;
 		if (initialSize != 0)
-			queryParams += "&before="+messageCache.getLast().getID();
+			queryParams += "&before="+messageCache.getLast().getStringID();
 
 		MessageObject[] messages = new MessageObject[0];
 		try {
-			messages = DiscordUtils.MAPPER.readValue(client.REQUESTS.GET.makeRequest(DiscordEndpoints.CHANNELS+channel.getID()+"/messages"+queryParams), MessageObject[].class);
+			messages = DiscordUtils.MAPPER.readValue(client.REQUESTS.GET.makeRequest(DiscordEndpoints.CHANNELS+channel.getStringID()+"/messages"+queryParams), MessageObject[].class);
 		} catch (IOException e) {
 			throw new DiscordException("JSON Parsing exception!", e);
 		}
@@ -253,7 +253,7 @@ public class MessageList extends AbstractList<IMessage> implements List<IMessage
 	 * @return True if found, false if otherwise.
 	 */
 	public boolean contains(String id) {
-		return messageCache.stream().filter(it -> it.getID().equals(id)).findFirst().isPresent();
+		return messageCache.stream().filter(it -> it.getStringID().equals(id)).findFirst().isPresent();
 	}
 
 	/**
@@ -356,12 +356,12 @@ public class MessageList extends AbstractList<IMessage> implements List<IMessage
 	 * @return The message object found, or null if nonexistent.
 	 */
 	public IMessage get(String id) {
-		IMessage message = stream().filter((m) -> m.getID().equalsIgnoreCase(id)).findFirst().orElse(null);
+		IMessage message = stream().filter((m) -> m.getStringID().equalsIgnoreCase(id)).findFirst().orElse(null);
 
 		if (message == null && hasPermissions() && client.isReady())
 			try {
 				return DiscordUtils.getMessageFromJSON((Channel) channel, client.REQUESTS.GET.makeRequest(
-						DiscordEndpoints.CHANNELS + channel.getID() + "/messages/" + id,
+						DiscordEndpoints.CHANNELS + channel.getStringID() + "/messages/" + id,
 						MessageObject.class));
 			} catch (Exception ignored) {}
 
@@ -589,7 +589,7 @@ public class MessageList extends AbstractList<IMessage> implements List<IMessage
 			throw new DiscordException("Must provide at least 2 and fewer than 100 messages to delete.");
 
 		long invalidCount = messages.stream()
-				.mapToLong(it -> Long.parseLong(it.getID()))
+				.mapToLong(IIDLinkedObject::getLongID)
 				.filter(id -> id < (((System.currentTimeMillis() - 14 * 24 * 60 * 60 * 1000) - 1420070400000L) << 22)) // Taken from Jake
 				// IF THE ID IS LESS THAN TWO WEEKS AGO SUBTRACT DISCORD EPOCH BITSHIFT LEFT 22 THEN COUNT IT BECAUSE IT'S BAD
 				.count();
@@ -597,7 +597,7 @@ public class MessageList extends AbstractList<IMessage> implements List<IMessage
 			throw new DiscordException(String.format("%d messages cannot be bulk deleted! They are more than 2 weeks old.", invalidCount));
 
 		client.REQUESTS.POST.makeRequest(
-				DiscordEndpoints.CHANNELS + channel.getID() + "/messages/bulk-delete",
+				DiscordEndpoints.CHANNELS + channel.getStringID() + "/messages/bulk-delete",
 				new BulkDeleteRequest(messages));
 	}
 

--- a/src/main/java/sx/blah/discord/util/MessageTokenizer.java
+++ b/src/main/java/sx/blah/discord/util/MessageTokenizer.java
@@ -549,7 +549,7 @@ public class MessageTokenizer {
 		private UserMentionToken(MessageTokenizer tokenizer, int startIndex, int endIndex) {
 			super(tokenizer, startIndex, endIndex, null);
 
-			mention = tokenizer.getClient().getUserByID(getContent().replaceAll("<@!?", "").replace(">", ""));
+			mention = tokenizer.getClient().getUserByID(Long.parseUnsignedLong(getContent().replaceAll("<@!?", "").replace(">", "")));
 
 			isNickname = getContent().contains("<@!");
 		}
@@ -576,7 +576,7 @@ public class MessageTokenizer {
 		private RoleMentionToken(MessageTokenizer tokenizer, int startIndex, int endIndex) {
 			super(tokenizer, startIndex, endIndex, null);
 
-			mention = tokenizer.getClient().getRoleByID(getContent().replace("<@&", "").replace(">", ""));
+			mention = tokenizer.getClient().getRoleByID(Long.parseUnsignedLong(getContent().replace("<@&", "").replace(">", "")));
 		}
 	}
 
@@ -592,7 +592,7 @@ public class MessageTokenizer {
 		private ChannelMentionToken(MessageTokenizer tokenizer, int startIndex, int endIndex) {
 			super(tokenizer, startIndex, endIndex, null);
 
-			mention = tokenizer.getClient().getChannelByID(getContent().replace("<#", "").replace(">", ""));
+			mention = tokenizer.getClient().getChannelByID(Long.parseUnsignedLong(getContent().replace("<#", "").replace(">", "")));
 		}
 	}
 
@@ -614,10 +614,10 @@ public class MessageTokenizer {
 			super(tokenizer, startIndex, endIndex);
 
 			final String content = getContent();
-			final String emojiId = content.substring(content.lastIndexOf(":") + 1, content.length());
+			final long emojiId = Long.parseUnsignedLong(content.substring(content.lastIndexOf(":") + 1, content.length()));
 
 			emoji = tokenizer.getClient().getGuilds().stream()
-					.map(guild -> guild.getEmojiByID(emojiId) != null ? guild.getEmojiByID(emojiId) : null).findFirst()
+					.map(guild -> guild.getEmojiByID(emojiId)).findFirst()
 					.orElse(null);
 		}
 

--- a/src/main/java/sx/blah/discord/util/cache/LongMap.java
+++ b/src/main/java/sx/blah/discord/util/cache/LongMap.java
@@ -1,0 +1,253 @@
+/*
+ *     This file is part of Discord4J.
+ *
+ *     Discord4J is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU Lesser General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     Discord4J is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU Lesser General Public License for more details.
+ *
+ *     You should have received a copy of the GNU Lesser General Public License
+ *     along with Discord4J.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package sx.blah.discord.util.cache;
+
+import com.koloboke.collect.LongCursor;
+import com.koloboke.collect.LongIterator;
+import com.koloboke.collect.set.LongSet;
+import com.koloboke.compile.KolobokeMap;
+import com.koloboke.function.LongObjConsumer;
+import com.koloboke.function.LongObjPredicate;
+
+import javax.annotation.Nonnull;
+import java.util.AbstractSet;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.function.Consumer;
+import java.util.function.LongConsumer;
+import java.util.function.LongPredicate;
+import java.util.function.Predicate;
+
+@KolobokeMap
+public interface LongMap<T> {
+	static <T> LongMap<T> newMap() {
+		return new KolobokeLongMap<>(64);
+	}
+
+	static <T> LongMap<T> copyMap(LongMap<T> map) {
+		LongMap<T> cache = newMap();
+		map.keySet().forEach((long key) -> cache.put(key, map.get(key)));
+		return cache;
+	}
+
+	@SuppressWarnings("unchecked")
+	static <T> LongMap<T> emptyMap() {
+		return (LongMap<T>) EmptyLongMap.INSTANCE;
+	}
+
+	boolean containsKey(long key);
+
+	T get(long key);
+
+	T put(long key, T value);
+
+	T remove(long key);
+
+	void clear();
+
+	int size();
+
+	LongSet keySet();
+
+	Collection<T> values();
+
+	void forEach(LongObjConsumer<? super T> action);
+
+	boolean forEachWhile(LongObjPredicate<? super T> predicate);
+
+	final class EmptyLongMap<T> implements LongMap<T> {
+		private static final LongMap<Object> INSTANCE = new EmptyLongMap<>();
+
+		@Override
+		public boolean containsKey(long key) {
+			return false;
+		}
+
+		@Override
+		public T get(long key) {
+			return null;
+		}
+
+		@Override
+		public T put(long key, T value) {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public T remove(long key) {
+			return null;
+		}
+
+		@Override
+		public void clear() {
+
+		}
+
+		@Override
+		public int size() {
+			return 0;
+		}
+
+		@Override
+		public LongSet keySet() {
+			return EmptyLongSet.INSTANCE;
+		}
+
+		@Override
+		public Collection<T> values() {
+			return Collections.emptyList();
+		}
+
+		@Override
+		public void forEach(LongObjConsumer<? super T> action) {
+
+		}
+
+		@Override
+		public boolean forEachWhile(LongObjPredicate<? super T> predicate) {
+			return true;
+		}
+	}
+
+	final class EmptyLongSet extends AbstractSet<Long> implements LongSet {
+		public static final LongSet INSTANCE = new EmptyLongSet();
+
+		@Override
+		public boolean contains(long l) {
+			return false;
+		}
+
+		@Nonnull
+		@Override
+		public long[] toLongArray() {
+			return new long[0];
+		}
+
+		@Nonnull
+		@Override
+		public long[] toArray(@Nonnull long[] longs) {
+			return new long[0];
+		}
+
+		@Nonnull
+		@Override
+		public LongCursor cursor() {
+			return new LongCursor() {
+				@Override
+				public void forEachForward(@Nonnull LongConsumer longConsumer) {
+
+				}
+
+				@Override
+				public long elem() {
+					throw new UnsupportedOperationException();
+				}
+
+				@Override
+				public boolean moveNext() {
+					return false;
+				}
+
+				@Override
+				public void remove() {
+					throw new UnsupportedOperationException();
+				}
+			};
+		}
+
+		@Override
+		public void forEach(@Nonnull Consumer<? super Long> consumer) {
+
+		}
+
+		@Override
+		public void forEach(@Nonnull LongConsumer longConsumer) {
+
+		}
+
+		@Override
+		public boolean forEachWhile(@Nonnull LongPredicate longPredicate) {
+			return false;
+		}
+
+		@Override
+		public boolean add(long l) {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public boolean removeLong(long l) {
+			return false;
+		}
+
+		@Override
+		public boolean removeIf(@Nonnull Predicate<? super Long> predicate) {
+			return false;
+		}
+
+		@Override
+		public boolean removeIf(@Nonnull LongPredicate longPredicate) {
+			return false;
+		}
+
+		@Override
+		public long sizeAsLong() {
+			return 0;
+		}
+
+		@Override
+		public boolean ensureCapacity(long l) {
+			return false;
+		}
+
+		@Override
+		public boolean shrink() {
+			return false;
+		}
+
+		@Override
+		public LongIterator iterator() {
+			return new LongIterator() {
+				@Override
+				public long nextLong() {
+					throw new UnsupportedOperationException();
+				}
+
+				@Override
+				public void forEachRemaining(@Nonnull Consumer<? super Long> consumer) {
+
+				}
+
+				@Override
+				public void forEachRemaining(@Nonnull LongConsumer longConsumer) {
+
+				}
+
+				@Override
+				public boolean hasNext() {
+					return false;
+				}
+			};
+		}
+
+		@Override
+		public int size() {
+			return 0;
+		}
+	}
+}

--- a/src/test/java/sx/blah/discord/SpoofBot.java
+++ b/src/test/java/sx/blah/discord/SpoofBot.java
@@ -51,7 +51,7 @@ public class SpoofBot {
 	private final IDiscordClient other;
 	private final IDiscordClient client;
 
-	public SpoofBot(IDiscordClient other, String token, String channelID) throws Exception {
+	public SpoofBot(IDiscordClient other, String token, long channelID) throws Exception {
 		this.other = other;
 		client = new ClientBuilder().withToken(token).login();
 		client.getDispatcher().registerListener(new IListener<ReadyEvent>() {

--- a/src/test/java/sx/blah/discord/TestBot.java
+++ b/src/test/java/sx/blah/discord/TestBot.java
@@ -88,8 +88,8 @@ public class TestBot {
 					public void handle(ReadyEvent readyEvent) {
 						try {
 							//Initialize required data
-							final IChannel testChannel = client.getChannelByID(System.getenv("CHANNEL"));
-							final IChannel spoofChannel = client.getChannelByID(System.getenv("SPOOF_CHANNEL"));
+							final IChannel testChannel = client.getChannelByID(Long.parseUnsignedLong(System.getenv("CHANNEL")));
+							final IChannel spoofChannel = client.getChannelByID(Long.parseUnsignedLong(System.getenv("SPOOF_CHANNEL")));
 							String buildNumber = System.getenv("BUILD_ID");
 
 							IVoiceChannel channel = client.getVoiceChannels().stream().filter(voiceChannel-> voiceChannel.getName().equalsIgnoreCase("Annoying Shit")).findFirst().orElse(null);
@@ -117,7 +117,7 @@ public class TestBot {
 							}
 
 							//Time to unleash the ai
-							SpoofBot spoofBot = new SpoofBot(client, System.getenv("SPOOF"), System.getenv("SPOOF_CHANNEL"));
+							SpoofBot spoofBot = new SpoofBot(client, System.getenv("SPOOF"), Long.parseUnsignedLong(System.getenv("SPOOF_CHANNEL")));
 
 							final long now = System.currentTimeMillis();
 							new Thread(() -> {
@@ -170,12 +170,12 @@ public class TestBot {
 										e.printStackTrace();
 									}
 								} else if (m.getContent().startsWith(".clear")) {
-									IChannel c = client.getChannelByID(m.getChannel().getID());
+									IChannel c = client.getChannelByID(m.getChannel().getLongID());
 									if (null != c) {
-										c.getMessageHistory().stream().filter(message -> message.getAuthor().getID()
-												.equalsIgnoreCase(client.getOurUser().getID())).forEach(message -> {
+										c.getMessageHistory().stream().filter(message -> message.getAuthor().getLongID()
+												== client.getOurUser().getLongID()).forEach(message -> {
 											try {
-												Discord4J.LOGGER.debug("Attempting deletion of message {} by \"{}\" ({})", message.getID(), message.getAuthor().getName(), message.getContent());
+												Discord4J.LOGGER.debug("Attempting deletion of message {} by \"{}\" ({})", message.getStringID(), message.getAuthor().getName(), message.getContent());
 												message.delete();
 											} catch (MissingPermissionsException | RateLimitException | DiscordException e) {
 												e.printStackTrace();
@@ -227,7 +227,7 @@ public class TestBot {
 									StringJoiner roleJoiner = new StringJoiner(", ");
 									StringJoiner permissionsJoiner = new StringJoiner(", ");
 									for (IRole role : m.getMentions().get(0).getRolesForGuild(m.getChannel().getGuild())) {
-										Discord4J.LOGGER.info("{}", role.getID());
+										Discord4J.LOGGER.info("{}", role.getStringID());
 										for (Permissions permissions : role.getPermissions()) {
 											permissionsJoiner.add(permissions.toString());
 										}
@@ -235,7 +235,7 @@ public class TestBot {
 										permissionsJoiner = new StringJoiner(", ");
 									}
 									try {
-										Discord4J.LOGGER.info("{}", m.getAuthor().getID());
+										Discord4J.LOGGER.info("{}", m.getAuthor().getStringID());
 										m.reply("This user has the following roles and permissions: "+roleJoiner.toString());
 									} catch (MissingPermissionsException | RateLimitException | DiscordException e) {
 										e.printStackTrace();


### PR DESCRIPTION
Safely migrate from String ids to long ids, without breaking API compatibility (all old methods marked as deprecated, but still works).