### PR TITLE
Add a null check to event.guild_id for presenceUpdates

### DIFF
--- a/src/main/java/sx/blah/discord/api/internal/DispatchHandler.java
+++ b/src/main/java/sx/blah/discord/api/internal/DispatchHandler.java
@@ -449,7 +449,7 @@ class DispatchHandler {
 
 	private void presenceUpdate(PresenceUpdateEventResponse event) {
 		IPresence presence = DiscordUtils.getPresenceFromJSON(event);
-		Guild guild = (Guild) client.getGuildByID(Long.parseUnsignedLong(event.guild_id));
+		Guild guild = event.guild_id == null ? null : (Guild) client.getGuildByID(Long.parseUnsignedLong(event.guild_id));
 		if (guild != null) {
 			User user = (User) guild.getUserByID(Long.parseUnsignedLong(event.user.id));
 			if (user != null) {


### PR DESCRIPTION
### Prerequisites
* [x] I have read and understood the [contribution guidelines](CONTRIBUTING.md)
* [x] This pull request follows the code style of the project
* [ ] I have tested this feature thoroughly
  * Set a breakpoint to set event.guild_id to null before the check, and no error was logged. Not exactly thorough, but it worked

**Issues Fixed:**
* When a presence update event was dispatched with a null or missing guild_id, `Long.parseUnsignedLong` would throw a `java.lang.NumberFormatException`, due to it being null. 

### Changes Proposed in this Pull Request
* Add a ternary operator to the retrieval of the guild for a presence update, checking if `event.guild_id` is null, and if so it returns null, otherwise it does what it did before to retrieve the guild.

