### PR TITLE
Add check to ensure guild is cached on guild delete events (fixes #283)

### DIFF
--- a/src/main/java/sx/blah/discord/api/internal/DispatchHandler.java
+++ b/src/main/java/sx/blah/discord/api/internal/DispatchHandler.java
@@ -474,12 +474,14 @@ class DispatchHandler {
 		Guild guild = (Guild) client.getGuildByID(guildId);
 
 		// Clean up cache
-		((ShardImpl) guild.getShard()).guildCache.remove(guild);
-		((User) client.getOurUser()).voiceStates.remove(guild.getLongID());
-		DiscordVoiceWS vWS = shard.voiceWebSockets.get(guildId);
-		if (vWS != null) {
-			vWS.disconnect(VoiceDisconnectedEvent.Reason.LEFT_CHANNEL);
-			shard.voiceWebSockets.remove(guildId);
+		if (guild != null) {
+			((ShardImpl) guild.getShard()).guildCache.remove(guild);
+			((User) client.getOurUser()).voiceStates.remove(guild.getLongID());
+			DiscordVoiceWS vWS = shard.voiceWebSockets.get(guildId);
+			if (vWS != null) {
+				vWS.disconnect(VoiceDisconnectedEvent.Reason.LEFT_CHANNEL);
+				shard.voiceWebSockets.remove(guildId);
+			}
 		}
 
 		if (json.unavailable) { //Guild can't be reached


### PR DESCRIPTION
- Checks if guild fetched from shard's cache is null
- Only happens if a guild delete event is dispatched during login (while guilds are still being streamed)