### PR TITLE
Implement the ability to self mute and deafen

### DIFF
--- a/src/main/java/sx/blah/discord/api/IDiscordClient.java
+++ b/src/main/java/sx/blah/discord/api/IDiscordClient.java
@@ -156,6 +156,22 @@ public interface IDiscordClient {
 	void streaming(String playingText, String streamingUrl);
 
 	/**
+	 * Changes this user's self-muted state in a guild.
+	 *
+	 * @param guild The guild to mute this user in.
+	 * @param isSelfMuted The new self-muted state.
+	 */
+	void mute(IGuild guild, boolean isSelfMuted);
+
+	/**
+	 * Changes this user's self-deafened state in a guild.
+	 *
+	 * @param guild The guild to deafen this user in.
+	 * @param isSelfDeafened The new self-deafened state.
+	 */
+	void deafen(IGuild guild, boolean isSelfDeafened);
+
+	/**
 	 * Checks if the api is ready to be interacted with on all shards.
 	 * @see IShard#isReady()
 	 *

--- a/src/main/java/sx/blah/discord/handle/impl/obj/VoiceChannel.java
+++ b/src/main/java/sx/blah/discord/handle/impl/obj/VoiceChannel.java
@@ -120,10 +120,11 @@ public class VoiceChannel extends Channel implements IVoiceChannel {
 		DiscordUtils.checkPermissions(getClient().getOurUser(), this, EnumSet.of(Permissions.VOICE_CONNECT));
 
 		IVoiceState voiceState = getClient().getOurUser().getVoiceStateForGuild(getGuild());
-		boolean isMuted = voiceState != null && voiceState.isMuted();
-		boolean isDeafened = voiceState != null && voiceState.isDeafened();
+		boolean isSelfMuted = voiceState != null && voiceState.isSelfMuted();
+		boolean isSelfDeafened = voiceState != null && voiceState.isSelfDeafened();
+
 		((ShardImpl) getShard()).ws.send(GatewayOps.VOICE_STATE_UPDATE,
-				new VoiceStateUpdateRequest(getGuild().getStringID(), getStringID(), isMuted, isDeafened));
+				new VoiceStateUpdateRequest(getGuild().getStringID(), getStringID(), isSelfMuted, isSelfDeafened));
 	}
 
 	@Override
@@ -132,11 +133,11 @@ public class VoiceChannel extends Channel implements IVoiceChannel {
 		if (!isConnected()) return;
 
 		IVoiceState voiceState = getClient().getOurUser().getVoiceStateForGuild(getGuild());
-		boolean isMuted = voiceState != null && voiceState.isMuted();
-		boolean isDeafened = voiceState != null && voiceState.isDeafened();
+		boolean isSelfMuted = voiceState != null && voiceState.isSelfMuted();
+		boolean isSelfDeafened = voiceState != null && voiceState.isSelfDeafened();
 
 		((ShardImpl) getShard()).ws.send(GatewayOps.VOICE_STATE_UPDATE,
-				new VoiceStateUpdateRequest(getGuild().getStringID(), null, isMuted, isDeafened));
+				new VoiceStateUpdateRequest(getGuild().getStringID(), null, isSelfMuted, isSelfDeafened));
 
 		DiscordVoiceWS vWS = ((ShardImpl) getShard()).voiceWebSockets.get(getGuild().getLongID());
 		if (vWS != null) {

--- a/src/main/java/sx/blah/discord/handle/impl/obj/VoiceState.java
+++ b/src/main/java/sx/blah/discord/handle/impl/obj/VoiceState.java
@@ -30,8 +30,8 @@ public class VoiceState implements IVoiceState {
 	private final String sessionID;
 	private boolean isDeafened;
 	private boolean isMuted;
-	private final boolean isSelfDeafened;
-	private final boolean isSelfMuted;
+	private boolean isSelfDeafened;
+	private boolean isSelfMuted;
 	private final boolean isSuppressed;
 
 	public VoiceState(IGuild guild, IVoiceChannel channel, IUser user, String sessionID, boolean isDeafened, boolean isMuted, boolean isSelfDeafened, boolean isSelfMuted, boolean isSuppressed) {
@@ -93,9 +93,17 @@ public class VoiceState implements IVoiceState {
 		return isSelfDeafened;
 	}
 
+	public void setSelfDeafened(boolean isSelfDeafened) {
+		this.isSelfDeafened = isSelfDeafened;
+	}
+
 	@Override
 	public boolean isSelfMuted() {
 		return isSelfMuted;
+	}
+
+	public void setSelfMuted(boolean isSelfMuted) {
+		this.isSelfMuted = isSelfMuted;
 	}
 
 	@Override


### PR DESCRIPTION
### Prerequisites
* [x] I have read and understood the [contribution guidelines](CONTRIBUTING.md)
* [x] This pull request follows the code style of the project
* [x] I have tested this feature thoroughly
  * [Proof of testing](https://gist.github.com/theIglooo/fdae2f675e626892bb6df194008f3733)
  * It isn't much, just logs of me changing server deafen/mute and self deafen/mute to make sure it's cached and working properly.

**Issues Fixed:** #294 

### Changes Proposed in this Pull Request
* Add `IDiscordClient.mute(IGuild, boolean)` and `IDiscordClient.deafen(IGuild, boolean)` to control the bot user's local mute and deafened state.
* Switches the parameters provided on voice join/leave from server mute/deafen to self mute/deafen.
* Removed final from `VoiceState#isSelfMuted` and `VoiceState#isSelfDeafened` and added setters for each.