### PR TITLE
Fix MessageTokenizer#nextRegex ignoring the pattern argument

### DIFF
--- a/src/main/java/sx/blah/discord/util/MessageTokenizer.java
+++ b/src/main/java/sx/blah/discord/util/MessageTokenizer.java
@@ -275,7 +275,7 @@ public class MessageTokenizer {
 		if (!hasNextRegex(pattern))
 			throw new IllegalStateException("No more occurrences found!");
 
-		Matcher matcher = ANY_MENTION_PATTERN.matcher(remaining);
+		Matcher matcher = pattern.matcher(remaining);
 		if (!matcher.find())
 			throw new IllegalStateException("Couldn't find any matches!");
 		final int start = currentPosition + matcher.start();

--- a/src/main/java/sx/blah/discord/util/MessageTokenizer.java
+++ b/src/main/java/sx/blah/discord/util/MessageTokenizer.java
@@ -23,6 +23,7 @@ import sx.blah.discord.Discord4J;
 import sx.blah.discord.api.IDiscordClient;
 import sx.blah.discord.handle.obj.*;
 
+import java.util.Objects;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -614,10 +615,10 @@ public class MessageTokenizer {
 			super(tokenizer, startIndex, endIndex);
 
 			final String content = getContent();
-			final long emojiId = Long.parseUnsignedLong(content.substring(content.lastIndexOf(":") + 1, content.length()));
+			final long emojiId = Long.parseUnsignedLong(content.substring(content.lastIndexOf(":") + 1, content.lastIndexOf('>')));
 
 			emoji = tokenizer.getClient().getGuilds().stream()
-					.map(guild -> guild.getEmojiByID(emojiId)).findFirst()
+					.map(guild -> guild.getEmojiByID(emojiId)).filter(Objects::nonNull).findFirst()
 					.orElse(null);
 		}
 


### PR DESCRIPTION
### Prerequisites
* [x] I have read and understood the [contribution guidelines](CONTRIBUTING.md)
* [x] This pull request follows the code style of the project
* [x] I have tested this feature thoroughly

### Changes Proposed in this Pull Request
* Fixes `MessageTokenizer#nextRegex` not using the argument pattern


