### PR TITLE
Clarified Behavior and Documentation for IVoiceChannel

### DIFF
--- a/src/main/java/sx/blah/discord/handle/impl/obj/PrivateChannel.java
+++ b/src/main/java/sx/blah/discord/handle/impl/obj/PrivateChannel.java
@@ -59,12 +59,12 @@ public class PrivateChannel extends Channel implements IPrivateChannel {
 
 	@Override
 	public LongMap<PermissionOverride> getUserOverridesLong() {
-		return LongMap.emptyMap();
+		throw new UnsupportedOperationException();
 	}
 
 	@Override
 	public LongMap<PermissionOverride> getRoleOverridesLong() {
-		return LongMap.emptyMap();
+		throw new UnsupportedOperationException();
 	}
 
 	@Override
@@ -73,6 +73,16 @@ public class PrivateChannel extends Channel implements IPrivateChannel {
 			return EnumSet.allOf(Permissions.class);
 
 		return EnumSet.noneOf(Permissions.class);
+	}
+
+	@Override
+	public void edit(String name, int position, String topic) {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public List<IExtendedInvite> getExtendedInvites() {
+		throw new UnsupportedOperationException();
 	}
 
 	@Override
@@ -152,12 +162,12 @@ public class PrivateChannel extends Channel implements IPrivateChannel {
 
 	@Override
 	public String getTopic() {
-		return "";
+		throw new UnsupportedOperationException();
 	}
 
 	@Override
 	public IGuild getGuild() {
-		return null;
+		throw new UnsupportedOperationException();
 	}
 
 	@Override
@@ -232,11 +242,11 @@ public class PrivateChannel extends Channel implements IPrivateChannel {
 
 	@Override
 	public boolean isDeleted() {
-		return false;
+		throw new UnsupportedOperationException();
 	}
 
 	@Override
 	public boolean isNSFW() {
-		return false;
+		throw new UnsupportedOperationException();
 	}
 }

--- a/src/main/java/sx/blah/discord/handle/impl/obj/VoiceChannel.java
+++ b/src/main/java/sx/blah/discord/handle/impl/obj/VoiceChannel.java
@@ -247,22 +247,22 @@ public class VoiceChannel extends Channel implements IVoiceChannel {
 
 	@Override
 	public int getMaxInternalCacheCount() {
-		throw new UnsupportedOperationException();
+			return 0;
 	}
 
 	@Override
 	public int getInternalCacheCount() {
-		throw new UnsupportedOperationException();
+		return 0;
 	}
 
 	@Override
 	public IMessage getMessageByID(long messageID) {
-		throw new UnsupportedOperationException();
+		return null;
 	}
 
 	@Override
 	public String getTopic() {
-		throw new UnsupportedOperationException();
+		return "";
 	}
 
 	@Override
@@ -302,7 +302,7 @@ public class VoiceChannel extends Channel implements IVoiceChannel {
 
 	@Override
 	public synchronized boolean getTypingStatus() {
-		throw new UnsupportedOperationException();
+		return false;
 	}
 
 	@Override
@@ -317,7 +317,7 @@ public class VoiceChannel extends Channel implements IVoiceChannel {
 
 	@Override
 	public List<IMessage> getPinnedMessages() {
-		throw new UnsupportedOperationException();
+		return new ArrayList<>();
 	}
 
 	@Override
@@ -382,6 +382,6 @@ public class VoiceChannel extends Channel implements IVoiceChannel {
 
 	@Override
 	public boolean isNSFW() {
-		throw new UnsupportedOperationException();
+		return false;
 	}
 }

--- a/src/main/java/sx/blah/discord/handle/impl/obj/VoiceChannel.java
+++ b/src/main/java/sx/blah/discord/handle/impl/obj/VoiceChannel.java
@@ -31,8 +31,6 @@ import sx.blah.discord.util.cache.Cache;
 import java.io.File;
 import java.io.InputStream;
 import java.time.LocalDateTime;
-import java.util.ArrayList;
-import java.util.EnumSet;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -247,22 +245,22 @@ public class VoiceChannel extends Channel implements IVoiceChannel {
 
 	@Override
 	public int getMaxInternalCacheCount() {
-			return 0;
+		throw new UnsupportedOperationException();
 	}
 
 	@Override
 	public int getInternalCacheCount() {
-		return 0;
+		throw new UnsupportedOperationException();
 	}
 
 	@Override
 	public IMessage getMessageByID(long messageID) {
-		return null;
+		throw new UnsupportedOperationException();
 	}
 
 	@Override
 	public String getTopic() {
-		return "";
+		throw new UnsupportedOperationException();
 	}
 
 	@Override
@@ -302,7 +300,7 @@ public class VoiceChannel extends Channel implements IVoiceChannel {
 
 	@Override
 	public synchronized boolean getTypingStatus() {
-		return false;
+		throw new UnsupportedOperationException();
 	}
 
 	@Override
@@ -317,7 +315,7 @@ public class VoiceChannel extends Channel implements IVoiceChannel {
 
 	@Override
 	public List<IMessage> getPinnedMessages() {
-		return new ArrayList<>();
+		throw new UnsupportedOperationException();
 	}
 
 	@Override
@@ -382,6 +380,6 @@ public class VoiceChannel extends Channel implements IVoiceChannel {
 
 	@Override
 	public boolean isNSFW() {
-		return false;
+		throw new UnsupportedOperationException();
 	}
 }

--- a/src/main/java/sx/blah/discord/handle/impl/obj/VoiceChannel.java
+++ b/src/main/java/sx/blah/discord/handle/impl/obj/VoiceChannel.java
@@ -247,22 +247,22 @@ public class VoiceChannel extends Channel implements IVoiceChannel {
 
 	@Override
 	public int getMaxInternalCacheCount() {
-		return 0;
+		throw new UnsupportedOperationException();
 	}
 
 	@Override
 	public int getInternalCacheCount() {
-		return 0;
+		throw new UnsupportedOperationException();
 	}
 
 	@Override
 	public IMessage getMessageByID(long messageID) {
-		return null;
+		throw new UnsupportedOperationException();
 	}
 
 	@Override
 	public String getTopic() {
-		return "";
+		throw new UnsupportedOperationException();
 	}
 
 	@Override
@@ -302,7 +302,7 @@ public class VoiceChannel extends Channel implements IVoiceChannel {
 
 	@Override
 	public synchronized boolean getTypingStatus() {
-		return false;
+		throw new UnsupportedOperationException();
 	}
 
 	@Override
@@ -317,7 +317,7 @@ public class VoiceChannel extends Channel implements IVoiceChannel {
 
 	@Override
 	public List<IMessage> getPinnedMessages() {
-		return new ArrayList<>();
+		throw new UnsupportedOperationException();
 	}
 
 	@Override
@@ -382,6 +382,6 @@ public class VoiceChannel extends Channel implements IVoiceChannel {
 
 	@Override
 	public boolean isNSFW() {
-		return false;
+		throw new UnsupportedOperationException();
 	}
 }

--- a/src/main/java/sx/blah/discord/handle/obj/IPrivateChannel.java
+++ b/src/main/java/sx/blah/discord/handle/obj/IPrivateChannel.java
@@ -17,8 +17,17 @@
 
 package sx.blah.discord.handle.obj;
 
+import sx.blah.discord.util.Image;
+
+import java.util.EnumSet;
+import java.util.List;
+
 /**
  * Represents a private channel where you could direct message a user.
+ * <p>
+ * Some methods from {@link IChannel}, when called, will always throw an exception due to the incompatible nature
+ * between a <i>guild</i> text channel (what IChannel typically represents) and a <i>private</i> text channel.
+ * All deprecated methods defined by this interface will throw an exception if invoked and should be avoided.
  */
 public interface IPrivateChannel extends IChannel {
 
@@ -33,4 +42,148 @@ public interface IPrivateChannel extends IChannel {
 	 * {@inheritDoc}
 	 */
 	IPrivateChannel copy();
+
+	/**
+	 * @deprecated  See {@link IPrivateChannel} for details.
+	 * @throws UnsupportedOperationException Impossible to use as a private channel.
+	 */
+	@Override
+	@Deprecated
+	EnumSet<Permissions> getModifiedPermissions(IRole role);
+
+	/**
+	 * @deprecated  See {@link IPrivateChannel} for details.
+	 * @throws UnsupportedOperationException Impossible to use as a private channel.
+	 */
+	@Override
+	@Deprecated
+	void removePermissionsOverride(IUser user);
+
+	/**
+	 * @deprecated  See {@link IPrivateChannel} for details.
+	 * @throws UnsupportedOperationException Impossible to use as a private channel.
+	 */
+	@Override
+	@Deprecated
+	void removePermissionsOverride(IRole role);
+
+	/**
+	 * @deprecated  See {@link IPrivateChannel} for details.
+	 * @throws UnsupportedOperationException Impossible to use as a private channel.
+	 */
+	@Override
+	@Deprecated
+	void overrideRolePermissions(IRole role, EnumSet<Permissions> toAdd, EnumSet<Permissions> toRemove);
+
+	/**
+	 * @deprecated  See {@link IPrivateChannel} for details.
+	 * @throws UnsupportedOperationException Impossible to use as a private channel.
+	 */
+	@Override
+	@Deprecated
+	void overrideUserPermissions(IUser user, EnumSet<Permissions> toAdd, EnumSet<Permissions> toRemove);
+
+	/**
+	 * @deprecated  See {@link IPrivateChannel} for details.
+	 * @throws UnsupportedOperationException Impossible to use as a private channel.
+	 */
+	@Override
+	@Deprecated
+	List<IInvite> getInvites();
+
+	/**
+	 * @deprecated  See {@link IPrivateChannel} for details.
+	 * @throws UnsupportedOperationException Impossible to use as a private channel.
+	 */
+	@Override
+	@Deprecated
+	void delete();
+
+	/**
+	 * @deprecated  See {@link IPrivateChannel} for details.
+	 * @throws UnsupportedOperationException Impossible to use as a private channel.
+	 */
+	@Override
+	@Deprecated
+	int getPosition();
+
+	/**
+	 * @deprecated  See {@link IPrivateChannel} for details.
+	 * @throws UnsupportedOperationException Impossible to use as a private channel.
+	 */
+	@Override
+	@Deprecated
+	void changeName(String name);
+
+	/**
+	 * @deprecated  See {@link IPrivateChannel} for details.
+	 * @throws UnsupportedOperationException Impossible to use as a private channel.
+	 */
+	@Override
+	@Deprecated
+	void changePosition(int position);
+
+	/**
+	 * @deprecated  See {@link IPrivateChannel} for details.
+	 * @throws UnsupportedOperationException Impossible to use as a private channel.
+	 */
+	@Override
+	@Deprecated
+	void changeTopic(String topic);
+
+	/**
+	 * @deprecated  See {@link IPrivateChannel} for details.
+	 * @throws UnsupportedOperationException Impossible to use as a private channel.
+	 */
+	@Override
+	@Deprecated
+	IExtendedInvite createInvite(int maxAge, int maxUses, boolean temporary, boolean unique);
+
+	/**
+	 * @deprecated  See {@link IPrivateChannel} for details.
+	 * @throws UnsupportedOperationException Impossible to use as a private channel.
+	 */
+	@Override
+	@Deprecated
+	List<IWebhook> getWebhooks();
+
+	/**
+	 * @deprecated  See {@link IPrivateChannel} for details.
+	 * @throws UnsupportedOperationException Impossible to use as a private channel.
+	 */
+	@Override
+	@Deprecated
+	IWebhook getWebhookByID(long id);
+
+	/**
+	 * @deprecated  See {@link IPrivateChannel} for details.
+	 * @throws UnsupportedOperationException Impossible to use as a private channel.
+	 */
+	@Override
+	@Deprecated
+	List<IWebhook> getWebhooksByName(String name);
+
+	/**
+	 * @deprecated  See {@link IPrivateChannel} for details.
+	 * @throws UnsupportedOperationException Impossible to use as a private channel.
+	 */
+	@Override
+	@Deprecated
+	IWebhook createWebhook(String name);
+
+	/**
+	 * @deprecated  See {@link IPrivateChannel} for details.
+	 * @throws UnsupportedOperationException Impossible to use as a private channel.
+	 */
+	@Override
+	@Deprecated
+	IWebhook createWebhook(String name, Image avatar);
+
+	/**
+	 * @deprecated  See {@link IPrivateChannel} for details.
+	 * @throws UnsupportedOperationException Impossible to use as a private channel.
+	 */
+	@Override
+	@Deprecated
+	IWebhook createWebhook(String name, String avatar);
 }

--- a/src/main/java/sx/blah/discord/handle/obj/IPrivateChannel.java
+++ b/src/main/java/sx/blah/discord/handle/obj/IPrivateChannel.java
@@ -194,14 +194,6 @@ public interface IPrivateChannel extends IChannel {
 	 */
 	@Override
 	@Deprecated
-	List<IMessage> getPinnedMessages();
-
-	/**
-	 * @deprecated See {@link IPrivateChannel} for details.
-	 * @throws UnsupportedOperationException Impossible to use as a private channel.
-	 */
-	@Override
-	@Deprecated
 	List<IWebhook> getWebhooks();
 
 	/**

--- a/src/main/java/sx/blah/discord/handle/obj/IPrivateChannel.java
+++ b/src/main/java/sx/blah/discord/handle/obj/IPrivateChannel.java
@@ -18,6 +18,7 @@
 package sx.blah.discord.handle.obj;
 
 import sx.blah.discord.util.Image;
+import sx.blah.discord.util.cache.LongMap;
 
 import java.util.EnumSet;
 import java.util.List;
@@ -44,7 +45,39 @@ public interface IPrivateChannel extends IChannel {
 	IPrivateChannel copy();
 
 	/**
-	 * @deprecated  See {@link IPrivateChannel} for details.
+	 * @deprecated See {@link IPrivateChannel} for details.
+	 * @throws UnsupportedOperationException Impossible to use as a private channel.
+	 */
+	@Override
+	@Deprecated
+	LongMap<PermissionOverride> getUserOverridesLong();
+
+	/**
+	 * @deprecated See {@link IPrivateChannel} for details.
+	 * @throws UnsupportedOperationException Impossible to use as a private channel.
+	 */
+	@Override
+	@Deprecated
+	LongMap<PermissionOverride> getRoleOverridesLong();
+
+	/**
+	 * @deprecated See {@link IPrivateChannel} for details.
+	 * @throws UnsupportedOperationException Impossible to use as a private channel.
+	 */
+	@Override
+	@Deprecated
+	void edit(String name, int position, String topic);
+
+	/**
+	 * @deprecated See {@link IPrivateChannel} for details.
+	 * @throws UnsupportedOperationException Impossible to use as a private channel.
+	 */
+	@Override
+	@Deprecated
+	List<IExtendedInvite> getExtendedInvites();
+
+	/**
+	 * @deprecated See {@link IPrivateChannel} for details.
 	 * @throws UnsupportedOperationException Impossible to use as a private channel.
 	 */
 	@Override
@@ -52,7 +85,7 @@ public interface IPrivateChannel extends IChannel {
 	EnumSet<Permissions> getModifiedPermissions(IRole role);
 
 	/**
-	 * @deprecated  See {@link IPrivateChannel} for details.
+	 * @deprecated See {@link IPrivateChannel} for details.
 	 * @throws UnsupportedOperationException Impossible to use as a private channel.
 	 */
 	@Override
@@ -60,7 +93,7 @@ public interface IPrivateChannel extends IChannel {
 	void removePermissionsOverride(IUser user);
 
 	/**
-	 * @deprecated  See {@link IPrivateChannel} for details.
+	 * @deprecated See {@link IPrivateChannel} for details.
 	 * @throws UnsupportedOperationException Impossible to use as a private channel.
 	 */
 	@Override
@@ -68,7 +101,7 @@ public interface IPrivateChannel extends IChannel {
 	void removePermissionsOverride(IRole role);
 
 	/**
-	 * @deprecated  See {@link IPrivateChannel} for details.
+	 * @deprecated See {@link IPrivateChannel} for details.
 	 * @throws UnsupportedOperationException Impossible to use as a private channel.
 	 */
 	@Override
@@ -76,7 +109,7 @@ public interface IPrivateChannel extends IChannel {
 	void overrideRolePermissions(IRole role, EnumSet<Permissions> toAdd, EnumSet<Permissions> toRemove);
 
 	/**
-	 * @deprecated  See {@link IPrivateChannel} for details.
+	 * @deprecated See {@link IPrivateChannel} for details.
 	 * @throws UnsupportedOperationException Impossible to use as a private channel.
 	 */
 	@Override
@@ -84,7 +117,7 @@ public interface IPrivateChannel extends IChannel {
 	void overrideUserPermissions(IUser user, EnumSet<Permissions> toAdd, EnumSet<Permissions> toRemove);
 
 	/**
-	 * @deprecated  See {@link IPrivateChannel} for details.
+	 * @deprecated See {@link IPrivateChannel} for details.
 	 * @throws UnsupportedOperationException Impossible to use as a private channel.
 	 */
 	@Override
@@ -92,7 +125,7 @@ public interface IPrivateChannel extends IChannel {
 	List<IInvite> getInvites();
 
 	/**
-	 * @deprecated  See {@link IPrivateChannel} for details.
+	 * @deprecated See {@link IPrivateChannel} for details.
 	 * @throws UnsupportedOperationException Impossible to use as a private channel.
 	 */
 	@Override
@@ -100,7 +133,7 @@ public interface IPrivateChannel extends IChannel {
 	void delete();
 
 	/**
-	 * @deprecated  See {@link IPrivateChannel} for details.
+	 * @deprecated See {@link IPrivateChannel} for details.
 	 * @throws UnsupportedOperationException Impossible to use as a private channel.
 	 */
 	@Override
@@ -108,7 +141,7 @@ public interface IPrivateChannel extends IChannel {
 	int getPosition();
 
 	/**
-	 * @deprecated  See {@link IPrivateChannel} for details.
+	 * @deprecated See {@link IPrivateChannel} for details.
 	 * @throws UnsupportedOperationException Impossible to use as a private channel.
 	 */
 	@Override
@@ -116,7 +149,7 @@ public interface IPrivateChannel extends IChannel {
 	void changeName(String name);
 
 	/**
-	 * @deprecated  See {@link IPrivateChannel} for details.
+	 * @deprecated See {@link IPrivateChannel} for details.
 	 * @throws UnsupportedOperationException Impossible to use as a private channel.
 	 */
 	@Override
@@ -124,7 +157,7 @@ public interface IPrivateChannel extends IChannel {
 	void changePosition(int position);
 
 	/**
-	 * @deprecated  See {@link IPrivateChannel} for details.
+	 * @deprecated See {@link IPrivateChannel} for details.
 	 * @throws UnsupportedOperationException Impossible to use as a private channel.
 	 */
 	@Override
@@ -132,7 +165,7 @@ public interface IPrivateChannel extends IChannel {
 	void changeTopic(String topic);
 
 	/**
-	 * @deprecated  See {@link IPrivateChannel} for details.
+	 * @deprecated See {@link IPrivateChannel} for details.
 	 * @throws UnsupportedOperationException Impossible to use as a private channel.
 	 */
 	@Override
@@ -140,7 +173,31 @@ public interface IPrivateChannel extends IChannel {
 	IExtendedInvite createInvite(int maxAge, int maxUses, boolean temporary, boolean unique);
 
 	/**
-	 * @deprecated  See {@link IPrivateChannel} for details.
+	 * @deprecated See {@link IPrivateChannel} for details.
+	 * @throws UnsupportedOperationException Impossible to use as a private channel.
+	 */
+	@Override
+	@Deprecated
+	String getTopic();
+
+	/**
+	 * @deprecated See {@link IPrivateChannel} for details.
+	 * @throws UnsupportedOperationException Impossible to use as a private channel.
+	 */
+	@Override
+	@Deprecated
+	IGuild getGuild();
+
+	/**
+	 * @deprecated See {@link IPrivateChannel} for details.
+	 * @throws UnsupportedOperationException Impossible to use as a private channel.
+	 */
+	@Override
+	@Deprecated
+	List<IMessage> getPinnedMessages();
+
+	/**
+	 * @deprecated See {@link IPrivateChannel} for details.
 	 * @throws UnsupportedOperationException Impossible to use as a private channel.
 	 */
 	@Override
@@ -148,7 +205,7 @@ public interface IPrivateChannel extends IChannel {
 	List<IWebhook> getWebhooks();
 
 	/**
-	 * @deprecated  See {@link IPrivateChannel} for details.
+	 * @deprecated See {@link IPrivateChannel} for details.
 	 * @throws UnsupportedOperationException Impossible to use as a private channel.
 	 */
 	@Override
@@ -156,7 +213,7 @@ public interface IPrivateChannel extends IChannel {
 	IWebhook getWebhookByID(long id);
 
 	/**
-	 * @deprecated  See {@link IPrivateChannel} for details.
+	 * @deprecated See {@link IPrivateChannel} for details.
 	 * @throws UnsupportedOperationException Impossible to use as a private channel.
 	 */
 	@Override
@@ -164,7 +221,7 @@ public interface IPrivateChannel extends IChannel {
 	List<IWebhook> getWebhooksByName(String name);
 
 	/**
-	 * @deprecated  See {@link IPrivateChannel} for details.
+	 * @deprecated See {@link IPrivateChannel} for details.
 	 * @throws UnsupportedOperationException Impossible to use as a private channel.
 	 */
 	@Override
@@ -172,7 +229,7 @@ public interface IPrivateChannel extends IChannel {
 	IWebhook createWebhook(String name);
 
 	/**
-	 * @deprecated  See {@link IPrivateChannel} for details.
+	 * @deprecated See {@link IPrivateChannel} for details.
 	 * @throws UnsupportedOperationException Impossible to use as a private channel.
 	 */
 	@Override
@@ -180,10 +237,26 @@ public interface IPrivateChannel extends IChannel {
 	IWebhook createWebhook(String name, Image avatar);
 
 	/**
-	 * @deprecated  See {@link IPrivateChannel} for details.
+	 * @deprecated See {@link IPrivateChannel} for details.
 	 * @throws UnsupportedOperationException Impossible to use as a private channel.
 	 */
 	@Override
 	@Deprecated
 	IWebhook createWebhook(String name, String avatar);
+
+	/**
+	 * @deprecated See {@link IPrivateChannel} for details.
+	 * @throws UnsupportedOperationException Impossible to use as a private channel.
+	 */
+	@Override
+	@Deprecated
+	boolean isDeleted();
+
+	/**
+	 * @deprecated See {@link IPrivateChannel} for details.
+	 * @throws UnsupportedOperationException Impossible to use as a private channel.
+	 */
+	@Override
+	@Deprecated
+	boolean isNSFW();
 }

--- a/src/main/java/sx/blah/discord/handle/obj/IVoiceChannel.java
+++ b/src/main/java/sx/blah/discord/handle/obj/IVoiceChannel.java
@@ -17,14 +17,19 @@
 
 package sx.blah.discord.handle.obj;
 
-import sx.blah.discord.util.DiscordException;
-import sx.blah.discord.util.MissingPermissionsException;
-import sx.blah.discord.util.RateLimitException;
+import sx.blah.discord.util.*;
 
+import java.io.File;
+import java.io.InputStream;
+import java.time.LocalDateTime;
 import java.util.List;
 
 /**
  * Represents a voice channel.
+ * <p>
+ * Most methods from {@link IChannel}, when called, will always throw an exception due to the incompatible nature
+ * between a text channel (what IChannel typically represents) and a voice channel. D4J v3 will fix this
+ * incompatibility, but in the meantime avoid any and all deprecated methods defined by this interface.
  */
 public interface IVoiceChannel extends IChannel {
 	/**
@@ -107,4 +112,316 @@ public interface IVoiceChannel extends IChannel {
 	 * @return The connected users.
 	 */
 	List<IUser> getConnectedUsers();
+
+	/**
+	 * @deprecated See {@link IVoiceChannel} for details.
+	 * @throws UnsupportedOperationException Impossible to use as a voice channel.
+	 */
+	@Override
+	@Deprecated
+	MessageList getMessages();
+
+	/**
+	 * @deprecated See {@link IVoiceChannel} for details.
+	 * @throws UnsupportedOperationException Impossible to use as a voice channel.
+	 */
+	@Override
+	@Deprecated
+	MessageHistory getMessageHistoryFrom(LocalDateTime startDate, int maxCount);
+
+	/**
+	 * @deprecated See {@link IVoiceChannel} for details.
+	 * @throws UnsupportedOperationException Impossible to use as a voice channel.
+	 */
+	@Override
+	@Deprecated
+	MessageHistory getMessageHistoryTo(LocalDateTime endDate, int maxCount);
+
+	/**
+	 * @deprecated See {@link IVoiceChannel} for details.
+	 * @throws UnsupportedOperationException Impossible to use as a voice channel.
+	 */
+	@Override
+	@Deprecated
+	MessageHistory getMessageHistoryIn(LocalDateTime startDate, LocalDateTime endDate, int maxCount);
+
+	/**
+	 * @deprecated See {@link IVoiceChannel} for details.
+	 * @throws UnsupportedOperationException Impossible to use as a voice channel.
+	 */
+	@Override
+	@Deprecated
+	MessageHistory getMessageHistoryFrom(long id, int maxCount);
+
+	/**
+	 * @deprecated See {@link IVoiceChannel} for details.
+	 * @throws UnsupportedOperationException Impossible to use as a voice channel.
+	 */
+	@Override
+	@Deprecated
+	MessageHistory getMessageHistoryTo(long id, int maxCount);
+
+	/**
+	 * @deprecated See {@link IVoiceChannel} for details.
+	 * @throws UnsupportedOperationException Impossible to use as a voice channel.
+	 */
+	@Override
+	@Deprecated
+	MessageHistory getMessageHistoryIn(long beginID, long endID, int maxCount);
+
+	/**
+	 * @deprecated See {@link IVoiceChannel} for details.
+	 * @throws UnsupportedOperationException Impossible to use as a voice channel.
+	 */
+	@Override
+	@Deprecated
+	MessageHistory getMessageHistory();
+
+	/**
+	 * @deprecated See {@link IVoiceChannel} for details.
+	 * @throws UnsupportedOperationException Impossible to use as a voice channel.
+	 */
+	@Override
+	@Deprecated
+	MessageHistory getMessageHistory(int messageCount);
+
+	/**
+	 * @deprecated See {@link IVoiceChannel} for details.
+	 * @throws UnsupportedOperationException Impossible to use as a voice channel.
+	 */
+	@Override
+	@Deprecated
+	MessageHistory getMessageHistoryFrom(LocalDateTime startDate);
+
+	/**
+	 * @deprecated See {@link IVoiceChannel} for details.
+	 * @throws UnsupportedOperationException Impossible to use as a voice channel.
+	 */
+	@Override
+	@Deprecated
+	MessageHistory getMessageHistoryTo(LocalDateTime endDate);
+
+	/**
+	 * @deprecated See {@link IVoiceChannel} for details.
+	 * @throws UnsupportedOperationException Impossible to use as a voice channel.
+	 */
+	@Override
+	@Deprecated
+	MessageHistory getMessageHistoryIn(LocalDateTime startDate, LocalDateTime endDate);
+
+	/**
+	 * @deprecated See {@link IVoiceChannel} for details.
+	 * @throws UnsupportedOperationException Impossible to use as a voice channel.
+	 */
+	@Override
+	@Deprecated
+	MessageHistory getMessageHistoryFrom(long id);
+
+	/**
+	 * @deprecated See {@link IVoiceChannel} for details.
+	 * @throws UnsupportedOperationException Impossible to use as a voice channel.
+	 */
+	@Override
+	@Deprecated
+	MessageHistory getMessageHistoryTo(long id);
+
+	/**
+	 * @deprecated See {@link IVoiceChannel} for details.
+	 * @throws UnsupportedOperationException Impossible to use as a voice channel.
+	 */
+	@Override
+	@Deprecated
+	MessageHistory getMessageHistoryIn(long beginID, long endID);
+
+	/**
+	 * @deprecated See {@link IVoiceChannel} for details.
+	 * @throws UnsupportedOperationException Impossible to use as a voice channel.
+	 */
+	@Override
+	@Deprecated
+	MessageHistory getFullMessageHistory();
+
+	/**
+	 * @deprecated See {@link IVoiceChannel} for details.
+	 * @throws UnsupportedOperationException Impossible to use as a voice channel.
+	 */
+	@Override
+	@Deprecated
+	List<IMessage> bulkDelete();
+
+	/**
+	 * @deprecated See {@link IVoiceChannel} for details.
+	 * @throws UnsupportedOperationException Impossible to use as a voice channel.
+	 */
+	@Override
+	@Deprecated
+	List<IMessage> bulkDelete(List<IMessage> messages);
+
+	/**
+	 * @deprecated See {@link IVoiceChannel} for details.
+	 * @throws UnsupportedOperationException Impossible to use as a voice channel.
+	 */
+	@Override
+	@Deprecated
+	int getMaxInternalCacheCount();
+
+	/**
+	 * @deprecated See {@link IVoiceChannel} for details.
+	 * @throws UnsupportedOperationException Impossible to use as a voice channel.
+	 */
+	@Override
+	@Deprecated
+	int getInternalCacheCount();
+
+	/**
+	 * @deprecated See {@link IVoiceChannel} for details.
+	 * @throws UnsupportedOperationException Impossible to use as a voice channel.
+	 */
+	@Override
+	@Deprecated
+	IMessage getMessageByID(long messageID);
+
+	/**
+	 * @deprecated See {@link IVoiceChannel} for details.
+	 * @throws UnsupportedOperationException Impossible to use as a voice channel.
+	 */
+	@Override
+	@Deprecated
+	String getTopic();
+
+	/**
+	 * @deprecated See {@link IVoiceChannel} for details.
+	 * @throws UnsupportedOperationException Impossible to use as a voice channel.
+	 */
+	@Override
+	@Deprecated
+	IMessage sendMessage(String content);
+
+	/**
+	 * @deprecated See {@link IVoiceChannel} for details.
+	 * @throws UnsupportedOperationException Impossible to use as a voice channel.
+	 */
+	@Override
+	@Deprecated
+	IMessage sendMessage(String content, boolean tts);
+
+	/**
+	 * @deprecated See {@link IVoiceChannel} for details.
+	 * @throws UnsupportedOperationException Impossible to use as a voice channel.
+	 */
+	@Override
+	@Deprecated
+	IMessage sendFile(File file);
+
+	/**
+	 * @deprecated See {@link IVoiceChannel} for details.
+	 * @throws UnsupportedOperationException Impossible to use as a voice channel.
+	 */
+	@Override
+	@Deprecated
+	IMessage sendFile(String content, File file);
+
+	/**
+	 * @deprecated See {@link IVoiceChannel} for details.
+	 * @throws UnsupportedOperationException Impossible to use as a voice channel.
+	 */
+	@Override
+	@Deprecated
+	IMessage sendFile(String content, boolean tts, InputStream file, String fileName);
+
+	/**
+	 * @deprecated See {@link IVoiceChannel} for details.
+	 * @throws UnsupportedOperationException Impossible to use as a voice channel.
+	 */
+	@Override
+	@Deprecated
+	void toggleTypingStatus();
+
+	/**
+	 * @deprecated See {@link IVoiceChannel} for details.
+	 * @throws UnsupportedOperationException Impossible to use as a voice channel.
+	 */
+	@Override
+	@Deprecated
+	boolean getTypingStatus();
+
+	/**
+	 * @deprecated See {@link IVoiceChannel} for details.
+	 * @throws UnsupportedOperationException Impossible to use as a voice channel.
+	 */
+	@Override
+	@Deprecated
+	void changeTopic(String topic);
+
+	/**
+	 * @deprecated See {@link IVoiceChannel} for details.
+	 * @throws UnsupportedOperationException Impossible to use as a voice channel.
+	 */
+	@Override
+	@Deprecated
+	void edit(String name, int position, String topic);
+
+	/**
+	 * @deprecated See {@link IVoiceChannel} for details.
+	 * @throws UnsupportedOperationException Impossible to use as a voice channel.
+	 */
+	@Override
+	@Deprecated
+	List<IMessage> getPinnedMessages();
+
+	/**
+	 * @deprecated See {@link IVoiceChannel} for details.
+	 * @throws UnsupportedOperationException Impossible to use as a voice channel.
+	 */
+	@Override
+	@Deprecated
+	List<IWebhook> getWebhooks();
+
+	/**
+	 * @deprecated See {@link IVoiceChannel} for details.
+	 * @throws UnsupportedOperationException Impossible to use as a voice channel.
+	 */
+	@Override
+	@Deprecated
+	IWebhook getWebhookByID(long id);
+
+	/**
+	 * @deprecated See {@link IVoiceChannel} for details.
+	 * @throws UnsupportedOperationException Impossible to use as a voice channel.
+	 */
+	@Override
+	@Deprecated
+	List<IWebhook> getWebhooksByName(String name);
+
+	/**
+	 * @deprecated See {@link IVoiceChannel} for details.
+	 * @throws UnsupportedOperationException Impossible to use as a voice channel.
+	 */
+	@Override
+	@Deprecated
+	IWebhook createWebhook(String name);
+
+	/**
+	 * @deprecated See {@link IVoiceChannel} for details.
+	 * @throws UnsupportedOperationException Impossible to use as a voice channel.
+	 */
+	@Override
+	@Deprecated
+	IWebhook createWebhook(String name, Image avatar);
+
+	/**
+	 * @deprecated See {@link IVoiceChannel} for details.
+	 * @throws UnsupportedOperationException Impossible to use as a voice channel.
+	 */
+	@Override
+	@Deprecated
+	IWebhook createWebhook(String name, String avatar);
+
+	/**
+	 * @deprecated See {@link IVoiceChannel} for details.
+	 * @throws UnsupportedOperationException Impossible to use as a voice channel.
+	 */
+	@Override
+	@Deprecated
+	boolean isNSFW();
 }

--- a/src/main/java/sx/blah/discord/handle/obj/IVoiceChannel.java
+++ b/src/main/java/sx/blah/discord/handle/obj/IVoiceChannel.java
@@ -28,8 +28,8 @@ import java.util.List;
  * Represents a voice channel.
  * <p>
  * Most methods from {@link IChannel}, when called, will always throw an exception due to the incompatible nature
- * between a text channel (what IChannel typically represents) and a voice channel. D4J v3 will fix this
- * incompatibility, but in the meantime avoid any and all deprecated methods defined by this interface.
+ * between a text channel (what IChannel typically represents) and a voice channel. All deprecated methods defined by
+ * this interface will throw an exception if invoked and should be avoided.
  */
 public interface IVoiceChannel extends IChannel {
 	/**


### PR DESCRIPTION
### Prerequisites
* [x] I have read and understood the [contribution guidelines](CONTRIBUTING.md)
* [x] This pull request follows the code style of the project
* [ ] I have tested this feature thoroughly
  * At the very most I used the TestBot and tested voice related commands and all of which worked. However, more testing is probably required to ensure that no part of D4J is blindly using the newly deprecated methods.

**Issues Fixed:** It is well known that the choice to have IVoiceChannel extend IChannel was...questionable. It simply does not make sense to "send a file" to a voice channel or to "get a message history" from a voice channel. To better clarify that this is problematic behavior, I have updated the documentation and deprecated methods that all would throw an `UnsupportedOperationException` for IVoiceChannel.

Additionally, I standardized behavior for a few other methods. It doesn't make sense to "get a topic" for an IVoiceChannel, for instance, so that has been changed to throw an exception, rather than returning an invalid value.

### Changes Proposed in this Pull Request
* Standardized expected behavior for VoiceChannel.
* Updated documentation for IVoiceChannel