### PR TITLE
Message History Cleanup

### DIFF
--- a/src/main/java/sx/blah/discord/api/internal/DiscordUtils.java
+++ b/src/main/java/sx/blah/discord/api/internal/DiscordUtils.java
@@ -118,6 +118,14 @@ public class DiscordUtils {
 	 */
 	public static final Pattern STREAM_URL_PATTERN = Pattern.compile("https?://(www\\.)?twitch\\.tv/.+");
 
+	public static long getSnowflakeFromTimestamp(long unixTime) {
+		return (unixTime - DISCORD_EPOCH) << 22;
+	}
+
+	public static long getSnowflakeFromTimestamp(LocalDateTime date) {
+		return getSnowflakeFromTimestamp(date.atZone(ZoneId.systemDefault()).toEpochSecond());
+	}
+
 	/**
 	 * Converts a String timestamp into a java object timestamp.
 	 *

--- a/src/main/java/sx/blah/discord/api/internal/DiscordUtils.java
+++ b/src/main/java/sx/blah/discord/api/internal/DiscordUtils.java
@@ -118,10 +118,28 @@ public class DiscordUtils {
 	 */
 	public static final Pattern STREAM_URL_PATTERN = Pattern.compile("https?://(www\\.)?twitch\\.tv/.+");
 
+	/**
+	 * Gets a snowflake from a unix timestamp.
+	 *
+	 * <p>This snowflake only contains accurate information about the timestamp (not about other parts of the snowflake).
+	 * The returned snowflake is only one of many that could exist at the given timestamp.
+	 *
+	 * @param unixTime The unix timestamp that should be used in the snowflake.
+	 * @return A snowflake with the given timestamp.
+	 */
 	public static long getSnowflakeFromTimestamp(long unixTime) {
 		return (unixTime - DISCORD_EPOCH) << 22;
 	}
 
+	/**
+	 * Gets a snowflake from a unix timestamp.
+	 *
+	 * <p>This snowflake only contains accurate information about the timestamp (not about other parts of the snowflake).
+	 * The returned snowflake is only one of many that could exist at the given timestamp.
+	 *
+	 * @param date The date that should be converted to a unix timestamp for use in the snowflake.
+	 * @return A snowflake with the given timestamp.
+	 */
 	public static long getSnowflakeFromTimestamp(LocalDateTime date) {
 		return getSnowflakeFromTimestamp(date.atZone(ZoneId.systemDefault()).toEpochSecond());
 	}

--- a/src/main/java/sx/blah/discord/handle/impl/obj/Channel.java
+++ b/src/main/java/sx/blah/discord/handle/impl/obj/Channel.java
@@ -207,10 +207,7 @@ public class Channel implements IChannel {
 			int chunkSize = messageCount < MESSAGE_CHUNK_COUNT ? messageCount : MESSAGE_CHUNK_COUNT;
 
 			while (retrieved.size() < messageCount) { // while we dont have messageCount messages
-				IMessage[] chunk = RequestBuffer.request(() ->
-					(IMessage[]) getHistory(lastMessage.get(), chunkSize)
-				).get();
-
+				IMessage[] chunk = getHistory(lastMessage.get(), chunkSize);
 				lastMessage.set(chunk[chunk.length - 1].getLongID());
 				Collections.addAll(retrieved, chunk);
 			}

--- a/src/main/java/sx/blah/discord/handle/obj/IChannel.java
+++ b/src/main/java/sx/blah/discord/handle/obj/IChannel.java
@@ -91,50 +91,6 @@ public interface IChannel extends IDiscordObject<IChannel> {
 	MessageHistory getMessageHistoryFrom(LocalDateTime startDate, int maxMessageCount);
 
 	/**
-	 * Gets the messages from now up until the specified date.
-	 * NOTE: This can block the current thread if messages need to be requested from Discord instead of fetched from
-	 * the internal cache.
-	 *
-	 * @param endDate The date to stop gathering messages at (inclusive).
-	 * @return The messages.
-	 */
-	MessageHistory getMessageHistoryTo(LocalDateTime endDate);
-
-	/**
-	 * Gets the messages from now up until the specified date.
-	 * NOTE: This can block the current thread if messages need to be requested from Discord instead of fetched from
-	 * the internal cache.
-	 *
-	 * @param endDate The date to stop gathering messages at (inclusive).
-	 * @param maxMessageCount The max number of messages to retrieve.
-	 * @return The messages.
-	 */
-	MessageHistory getMessageHistoryTo(LocalDateTime endDate, int maxMessageCount);
-
-	/**
-	 * Gets the messages in the specified range of dates.
-	 * NOTE: This can block the current thread if messages need to be requested from Discord instead of fetched from
-	 * the internal cache.
-	 *
-	 * @param startDate The date to start gathering messages from (inclusive).
-	 * @param endDate The date to stop gathering messages at (inclusive).
-	 * @return The messages.
-	 */
-	MessageHistory getMessageHistoryIn(LocalDateTime startDate, LocalDateTime endDate);
-
-	/**
-	 * Gets the messages in the specified range of dates.
-	 * NOTE: This can block the current thread if messages need to be requested from Discord instead of fetched from
-	 * the internal cache.
-	 *
-	 * @param startDate The date to start gathering messages from (inclusive).
-	 * @param endDate The date to stop gathering messages at (inclusive).
-	 * @param maxMessageCount The max number of messages to retrieve.
-	 * @return The messages.
-	 */
-	MessageHistory getMessageHistoryIn(LocalDateTime startDate, LocalDateTime endDate, int maxMessageCount);
-
-	/**
 	 * Gets the messages from a specified message id to the beginning of this channel.
 	 * NOTE: This can block the current thread if messages need to be requested from Discord instead of fetched from
 	 * the internal cache.
@@ -185,6 +141,27 @@ public interface IChannel extends IDiscordObject<IChannel> {
 	MessageHistory getMessageHistoryFrom(long id, int maxMessageCount);
 
 	/**
+	 * Gets the messages from now up until the specified date.
+	 * NOTE: This can block the current thread if messages need to be requested from Discord instead of fetched from
+	 * the internal cache.
+	 *
+	 * @param endDate The date to stop gathering messages at (inclusive).
+	 * @return The messages.
+	 */
+	MessageHistory getMessageHistoryTo(LocalDateTime endDate);
+
+	/**
+	 * Gets the messages from now up until the specified date.
+	 * NOTE: This can block the current thread if messages need to be requested from Discord instead of fetched from
+	 * the internal cache.
+	 *
+	 * @param endDate The date to stop gathering messages at (inclusive).
+	 * @param maxMessageCount The max number of messages to retrieve.
+	 * @return The messages.
+	 */
+	MessageHistory getMessageHistoryTo(LocalDateTime endDate, int maxMessageCount);
+
+	/**
 	 * Gets the messages from now up until the specified message id.
 	 * NOTE: This can block the current thread if messages need to be requested from Discord instead of fetched from
 	 * the internal cache.
@@ -233,6 +210,30 @@ public interface IChannel extends IDiscordObject<IChannel> {
 	 * @return The messages.
 	 */
 	MessageHistory getMessageHistoryTo(long id, int maxMessageCount);
+
+	/**
+	 * Gets the messages in the specified range of dates.
+	 * NOTE: This can block the current thread if messages need to be requested from Discord instead of fetched from
+	 * the internal cache.
+	 *
+	 * @param startDate The date to start gathering messages from (inclusive).
+	 * @param endDate The date to stop gathering messages at (inclusive).
+	 * @return The messages.
+	 */
+	MessageHistory getMessageHistoryIn(LocalDateTime startDate, LocalDateTime endDate);
+
+	/**
+	 * Gets the messages in the specified range of dates.
+	 * NOTE: This can block the current thread if messages need to be requested from Discord instead of fetched from
+	 * the internal cache.
+	 *
+	 * @param startDate The date to start gathering messages from (inclusive).
+	 * @param endDate The date to stop gathering messages at (inclusive).
+	 * @param maxMessageCount The max number of messages to retrieve.
+	 * @return The messages.
+	 */
+	MessageHistory getMessageHistoryIn(LocalDateTime startDate, LocalDateTime endDate, int maxMessageCount);
+
 
 	/**
 	 * Gets the messages in the specified range of message ids.

--- a/src/main/java/sx/blah/discord/util/MessageHistory.java
+++ b/src/main/java/sx/blah/discord/util/MessageHistory.java
@@ -80,9 +80,9 @@ public class MessageHistory extends AbstractList<IMessage> implements List<IMess
 	 * @return The earliest message.
 	 */
 	public IMessage getEarliestMessage() {
-		IMessage[] sorted = Arrays.copyOf(backing, backing.length);
-		Arrays.sort(sorted, MessageComparator.DEFAULT);
-		return sorted[0];
+		return Arrays.stream(backing)
+				.min(MessageComparator.DEFAULT)
+				.orElse(null);
 	}
 
 	/**
@@ -91,9 +91,9 @@ public class MessageHistory extends AbstractList<IMessage> implements List<IMess
 	 * @return The latest message.
 	 */
 	public IMessage getLatestMessage() {
-		IMessage[] sorted = Arrays.copyOf(backing, backing.length);
-		Arrays.sort(sorted, MessageComparator.REVERSED);
-		return sorted[0];
+		return Arrays.stream(backing)
+				.max(MessageComparator.DEFAULT)
+				.orElse(null);
 	}
 
 	/**


### PR DESCRIPTION
### Prerequisites
* [x] I have read and understood the [contribution guidelines](CONTRIBUTING.md)
* [x] This pull request follows the code style of the project
* [x] I have tested this feature thoroughly

**Issues Fixed:** 
#316 
#319 

### Changes Proposed in this Pull Request
1. Rewrote all message history methods to use `getMessageHistoryIn()`.

The rationale behind this change is to consolidate the logic of each history method to improve maintainability. All these methods are simply forms of getting a set of messages in a range so why not use the method for that purpose?

- `getMessageHistoryFrom()` is range `given time -> creation time`
- `getMessageHistoryTo()` is range `current time -> given time`
- `getFullMessageHistory()` is range `current time -> creation time`

2. Reworked history fetching to be based on timestamps

Discord's history API was made to be used in this way. Because snowflakes are (effectively) sequential, and they contain timestamps, we can calculate the minimum snowflake for a given timestamp and fetch history based on that. This makes the code for fetching *much* cleaner, increasing its maintainability.


These changes do **not** intend to change the way users use the methods. They are purely internal. With the exception of `getMessageHistoryIn()`, all of the methods have the same results. I exclude `getMessageHistoryIn()` as I was unable to find a version of Discord4J in which this method functioned at all (see #319)