### PR TITLE
6000 characters is the max for embeds

### DIFF
--- a/src/main/java/sx/blah/discord/util/EmbedBuilder.java
+++ b/src/main/java/sx/blah/discord/util/EmbedBuilder.java
@@ -64,7 +64,7 @@ public class EmbedBuilder {
 	/**
 	 * The maximum character limit across all visible fields.
 	 */
-	public static final int MAX_CHAR_LIMIT = 4000;
+	public static final int MAX_CHAR_LIMIT = 6000;
 
 	private final EmbedObject embed = new EmbedObject(null, "rich", null, null, null, 0, null, null, null, null, null,
 			null, null);


### PR DESCRIPTION
### Prerequisites
* [x] I have read and understood the [contribution guidelines](CONTRIBUTING.md)
* [x] This pull request follows the code style of the project
* [x] I have tested this feature thoroughly
  * sx.blah.discord.util.DiscordException: Error on request to https://discordapp.com/api/channels/313745225954623498/messages. Received response code 400. With response text: {"embed": ["Embed size exceeds maximum size of 6000"]}

**Issues Fixed:** Fixed max from 4K -> 6K

### Changes Proposed in this Pull Request
*

...


