### PR TITLE
Fixed reactions causing internal permission issues

### DIFF
--- a/src/main/java/sx/blah/discord/api/internal/DispatchHandler.java
+++ b/src/main/java/sx/blah/discord/api/internal/DispatchHandler.java
@@ -736,10 +736,7 @@ class DispatchHandler {
 		if (channel == null) return;
 
 		// Ensures that the cache doesn't flip if it doesn't have perms
-		Collection<Permissions> requiredPermissions = new ArrayList<>();
-		requiredPermissions.add(Permissions.READ_MESSAGE_HISTORY);
-		requiredPermissions.add(Permissions.READ_MESSAGES);
-		if (!channel.getModifiedPermissions(client.getOurUser()).containsAll(requiredPermissions)) return;
+		if (!channel.getModifiedPermissions(client.getOurUser()).containsAll(Arrays.asList(Permissions.READ_MESSAGES, Permissions.READ_MESSAGE_HISTORY))) return;
 
 		IMessage message = channel.getMessageByID(Long.parseUnsignedLong(event.message_id));
 		IReaction reaction = event.emoji.id == null
@@ -767,10 +764,7 @@ class DispatchHandler {
 		if (channel == null) return;
 
 		// Ensures that the cache doesn't flip if it doesn't have perms
-		Collection<Permissions> requiredPermissions = new ArrayList<>();
-		requiredPermissions.add(Permissions.READ_MESSAGE_HISTORY);
-		requiredPermissions.add(Permissions.READ_MESSAGES);
-		if (!channel.getModifiedPermissions(client.getOurUser()).containsAll(requiredPermissions)) return;
+		if (!channel.getModifiedPermissions(client.getOurUser()).containsAll(Arrays.asList(Permissions.READ_MESSAGES, Permissions.READ_MESSAGE_HISTORY))) return;
 
 		IMessage message = channel.getMessageByID(Long.parseUnsignedLong(event.message_id));
 		IReaction reaction = event.emoji.id == null

--- a/src/main/java/sx/blah/discord/api/internal/DispatchHandler.java
+++ b/src/main/java/sx/blah/discord/api/internal/DispatchHandler.java
@@ -735,7 +735,7 @@ class DispatchHandler {
 		IChannel channel = shard.getChannelByID(Long.parseUnsignedLong(event.channel_id));
 		if (channel == null) return;
 
-		// Ensures that the cache doesn't flip if it doesn't have perms
+		// Requires read message perms to view the channel (because discord sends this event regardless) and history perms to request the message
 		if (!channel.getModifiedPermissions(client.getOurUser()).containsAll(Arrays.asList(Permissions.READ_MESSAGES, Permissions.READ_MESSAGE_HISTORY))) return;
 
 		IMessage message = channel.getMessageByID(Long.parseUnsignedLong(event.message_id));
@@ -763,7 +763,7 @@ class DispatchHandler {
 		IChannel channel = shard.getChannelByID(Long.parseUnsignedLong(event.channel_id));
 		if (channel == null) return;
 
-		// Ensures that the cache doesn't flip if it doesn't have perms
+		// Requires read message perms to view the channel (because discord sends this event regardless) and history perms to request the message
 		if (!channel.getModifiedPermissions(client.getOurUser()).containsAll(Arrays.asList(Permissions.READ_MESSAGES, Permissions.READ_MESSAGE_HISTORY))) return;
 
 		IMessage message = channel.getMessageByID(Long.parseUnsignedLong(event.message_id));


### PR DESCRIPTION
### Prerequisites
* [x] I have read and understood the [contribution guidelines](CONTRIBUTING.md)
* [x] This pull request follows the code style of the project
* [x] I have tested this feature thoroughly
  * Took out history reading perms for my bot in my test server. This is before my change, adding a reaction: https://i.imgur.com/NV2oXmX.png This is after: https://i.imgur.com/cwUhCh5.png

**Issues Fixed:** Fixed internal permissions error for reactions

### Changes Proposed in this Pull Request
* Adding additional permission for checking