### PR TITLE
Added displayed color for users in guilds

### DIFF
--- a/src/main/java/sx/blah/discord/handle/impl/obj/User.java
+++ b/src/main/java/sx/blah/discord/handle/impl/obj/User.java
@@ -231,7 +231,7 @@ public class User implements IUser {
 		if (roleList.isEmpty()) return color;
 		
 		for (IRole role : roleList) {
-			if (role.getPosition() > maxPosition && !role.getColor().equals(color)) {
+			if (role.getPosition() > maxPosition && role.getColor().getRGB() != 0) {
 				maxPosition = role.getPosition();
 				color = role.getColor();
 			}

--- a/src/main/java/sx/blah/discord/handle/impl/obj/User.java
+++ b/src/main/java/sx/blah/discord/handle/impl/obj/User.java
@@ -33,6 +33,7 @@ import sx.blah.discord.util.PermissionUtils;
 import sx.blah.discord.util.cache.Cache;
 import sx.blah.discord.util.cache.LongMap;
 
+import java.awt.Color;
 import java.util.*;
 import java.util.concurrent.CopyOnWriteArraySet;
 
@@ -220,6 +221,23 @@ public class User implements IUser {
 		}
 
 		return new LinkedList<>();
+	}
+	
+	@Override
+	public Color getColorForGuild(IGuild guild) {
+		Color color = new Color(0);
+		int maxPosition = -1;
+		List<IRole> roleList = getRolesForGuild(guild);
+		if (roleList.isEmpty()) return color;
+		
+		for (IRole role : roleList) {
+			if (role.getPosition() > maxPosition && !role.getColor().equals(color)) {
+				maxPosition = role.getPosition();
+				color = role.getColor();
+			}
+		}
+		
+		return color;
 	}
 
 	@Override

--- a/src/main/java/sx/blah/discord/handle/obj/IUser.java
+++ b/src/main/java/sx/blah/discord/handle/obj/IUser.java
@@ -110,6 +110,14 @@ public interface IUser extends IDiscordObject<IUser> {
 	List<IRole> getRolesForGuild(IGuild guild);
 
 	/**
+	 * Gets the color the user's name is shown as in the given guild.
+	 *
+	 * @param guild The guild to get roles for.
+	 * @return The color the user has in the given guild.
+	 */
+	Color getColorForGuild(IGuild guild);
+
+	/**
 	 * Gets the permissions the user has in the given guild.
 	 *
 	 * @param guild The guild to get permissions for.


### PR DESCRIPTION
### Prerequisites
* [x] I have read and understood the [contribution guidelines](CONTRIBUTING.md)
* [x] This pull request follows the code style of the project
* [x] I have tested this feature thoroughly
  * Probably works

### Changes Proposed in this Pull Request
* Add a getColorForGuild(IGuild) method in IUser that returns the displayed color of the user in the given guild


