### PR TITLE
Added author name limit check

### DIFF
--- a/src/main/java/sx/blah/discord/util/EmbedBuilder.java
+++ b/src/main/java/sx/blah/discord/util/EmbedBuilder.java
@@ -58,6 +58,10 @@ public class EmbedBuilder {
 	 */
 	public static final int FOOTER_CONTENT_LIMIT = DESCRIPTION_CONTENT_LIMIT;
 	/**
+	 * The maximum length of author name.
+	 */
+	public static final int AUTHOR_NAME_LIMIT = 256;
+	/**
 	 * The maximum character limit across all visible fields.
 	 */
 	public static final int MAX_CHAR_LIMIT = 6000;
@@ -314,6 +318,14 @@ public class EmbedBuilder {
 	public EmbedBuilder withAuthorName(String name) {
 		if (embed.author == null)
 			embed.author = new EmbedObject.AuthorObject(null, null, null, null);
+		
+		if (name.trim().length() > AUTHOR_NAME_LIMIT) {
+			if (lenient)
+				name = name.substring(0, AUTHOR_NAME_LIMIT);
+			else
+				throw new IllegalArgumentException(
+						"Author name cannot have more than " + AUTHOR_NAME_LIMIT + " characters");
+		}
 
 		throwExceptionForCharacterLimit(name.trim().length());
 


### PR DESCRIPTION
### Prerequisites
* [x] I have read and understood the [contribution guidelines](CONTRIBUTING.md)
* [x] This pull request follows the code style of the project
* [ ] I have tested this feature thoroughly
  * I didn't test it but it small enough to not warrant any bugs.

**Issues Fixed:** EmbedBuilder now checks if author name does not exceed the limit (See https://discordapp.com/developers/docs/resources/channel#embed-limits)

