### PR TITLE
Fixed Regions to Allow VIP

### DIFF
--- a/src/main/java/sx/blah/discord/api/internal/DiscordClientImpl.java
+++ b/src/main/java/sx/blah/discord/api/internal/DiscordClientImpl.java
@@ -227,8 +227,8 @@ public final class DiscordClientImpl implements IDiscordClient {
 	}
 
 	public IRegion getGuildRegion(Guild guild) {
+		loadStandardRegions();
 		synchronized (regions) {
-			loadStandardRegions();
 			IRegion region = regions.get(guild.getRegionID());
 
 			if (region == null) { // New region types means Discord has updated
@@ -265,6 +265,7 @@ public final class DiscordClientImpl implements IDiscordClient {
 
 	@Override
 	public IRegion getRegionByID(String regionID) {
+		loadStandardRegions();
 		IRegion region = regions.get(regionID);
 
 		if (region == null) {

--- a/src/main/java/sx/blah/discord/api/internal/DiscordUtils.java
+++ b/src/main/java/sx/blah/discord/api/internal/DiscordUtils.java
@@ -305,7 +305,7 @@ public class DiscordUtils {
 			guild.setOwnerID(Long.parseUnsignedLong(json.owner_id));
 			guild.setAFKChannel(json.afk_channel_id == null ? 0 : Long.parseUnsignedLong(json.afk_channel_id));
 			guild.setAfkTimeout(json.afk_timeout);
-			guild.setRegion(json.region);
+			guild.setRegionID(json.region);
 			guild.setVerificationLevel(json.verification_level);
 			guild.setTotalMemberCount(json.member_count);
 
@@ -856,37 +856,6 @@ public class DiscordUtils {
 				toPCM.getSampleSizeInBits(), toPCM.getChannels(), toPCM.getFrameSize(), toPCM.getFrameRate(), true);
 
 		return AudioSystem.getAudioInputStream(audioFormat, pcmStream);
-	}
-
-	/**
-	 * Retrieves all standard regions (non-VIP regions).
-	 *
-	 * @param requests Used to send a request to Discord to get standard regions.
-	 * @return A list of standard, non-VIP regions.
-	 */
-	public static List<IRegion> getStandardRegions(Requests requests) {
-		VoiceRegionObject[] regions = requests.GET.makeRequest(
-				DiscordEndpoints.VOICE + "regions", VoiceRegionObject[].class);
-
-		return Arrays.stream(regions)
-				.map(DiscordUtils::getRegionFromJSON)
-				.collect(Collectors.toList());
-	}
-
-	/**
-	 * Retrieves all regions available to the guild, including VIP regions.
-	 *
-	 * @param requests Used to send a request to get available regions.
-	 * @param guild The guild to get the regions available to.
-	 * @return All regions available to the guild, including VIP regions.
-	 */
-	public static List<IRegion> getRegionsFromGuild(Requests requests, IGuild guild) {
-		VoiceRegionObject[] regions = requests.GET.makeRequest(
-				DiscordEndpoints.GUILDS + guild.getStringID() + "/regions", VoiceRegionObject[].class);
-
-		return Arrays.stream(regions)
-				.map(DiscordUtils::getRegionFromJSON)
-				.collect(Collectors.toList());
 	}
 
 	/**

--- a/src/main/java/sx/blah/discord/api/internal/DiscordUtils.java
+++ b/src/main/java/sx/blah/discord/api/internal/DiscordUtils.java
@@ -859,6 +859,37 @@ public class DiscordUtils {
 	}
 
 	/**
+	 * Retrieves all standard regions (non-VIP regions).
+	 *
+	 * @param requests Used to send a request to Discord to get standard regions.
+	 * @return A list of standard, non-VIP regions.
+	 */
+	public static List<IRegion> getStandardRegions(Requests requests) {
+		VoiceRegionObject[] regions = requests.GET.makeRequest(
+				DiscordEndpoints.VOICE + "regions", VoiceRegionObject[].class);
+
+		return Arrays.stream(regions)
+				.map(DiscordUtils::getRegionFromJSON)
+				.collect(Collectors.toList());
+	}
+
+	/**
+	 * Retrieves all regions available to the guild, including VIP regions.
+	 *
+	 * @param requests Used to send a request to get available regions.
+	 * @param guild The guild to get the regions available to.
+	 * @return All regions available to the guild, including VIP regions.
+	 */
+	public static List<IRegion> getRegionsFromGuild(Requests requests, IGuild guild) {
+		VoiceRegionObject[] regions = requests.GET.makeRequest(
+				DiscordEndpoints.GUILDS + guild.getStringID() + "/regions", VoiceRegionObject[].class);
+
+		return Arrays.stream(regions)
+				.map(DiscordUtils::getRegionFromJSON)
+				.collect(Collectors.toList());
+	}
+
+	/**
 	 * Creates a {@link ThreadFactory} which produces threads which run as daemons.
 	 *
 	 * @return The new daemon thread factory.


### PR DESCRIPTION
### Prerequisites
* [x] I have read and understood the [contribution guidelines](CONTRIBUTING.md)
* [x] This pull request follows the code style of the project
* [x] I have tested this feature thoroughly
  * ![hover](https://cdn.discordapp.com/attachments/208023865127862272/363925836744753153/unknown.png)

**Issues Fixed:** Issue #356 

### Changes Proposed in this Pull Request
* Moved updating of region cache to Guild object.

### Explanation
The current methodology of getting regions uses the [voice region](https://discordapp.com/developers/docs/resources/voice#list-voice-regions) endpoint (and it only does it once, when `IDiscordClient#getRegions` is first called). This is problematic because that endpoint does not return VIP regions.

So the logical step to fix this would be to simply check if a guild's region is VIP and just simply add it to the cache. The problem with this is guild's can initially be instantiated with that region, so you would have to use to use the [guild regions](https://discordapp.com/developers/docs/resources/guild#get-guild-voice-regions) endpoint to get the new IRegion object.

That's all well and good until updating happens. Now the cache needs to be updated somewhere and unlike every other cache we have it's not in the Guild object, it's in client. So we would have to have creation of the cache's logic in Guild, but the other in Dispatcher. So then this starts to become a bit messy.

So what this proposal does is move both creation and updating of that cache to the Guild object. A static lock is used because as Guild objects are being instantiated asynchronously, they may be hitting the endpoints multiple times, which is less than ideal for larger bots.

First, it checks if the cache has even been created, if not, then just simply fill it up with the standard regions. This is only done once, ever.

Second, if the region that the guild is a part of is not in the cache, then we get the region(s) in that guild and add it to the cache. This should only ever happen with VIP guilds that are not already in the cache.

The locks are held super quickly, and really shouldn't impact loading times. The only time they are held for any considerable amount of time is on the first standard population, then whenever a new VIP is introduced, which is rarely. Otherwise, the only performance impact is when a guild wants to change regions and it has to do two if checks, which should have negligibly performance since this isn't done too often, even for large amounts of guilds.