### PR TITLE
Fix reaction events distributing incorrect user info in DMs

### DIFF
--- a/src/main/java/sx/blah/discord/api/internal/DispatchHandler.java
+++ b/src/main/java/sx/blah/discord/api/internal/DispatchHandler.java
@@ -786,7 +786,7 @@ class DispatchHandler {
 
 		IUser user;
 		if (channel.isPrivate()) {
-			user = ((PrivateChannel) channel).getRecipient();
+			user = channel.getUsersHere().get(channel.getUsersHere().get(0).getLongID() == Long.parseUnsignedLong(event.user_id) ? 0 : 1);
 		} else {
 			user = channel.getGuild().getUserByID(Long.parseUnsignedLong(event.user_id));
 		}
@@ -811,7 +811,7 @@ class DispatchHandler {
 
 		IUser user;
 		if (channel.isPrivate()) {
-			user = ((PrivateChannel) channel).getRecipient();
+			user = channel.getUsersHere().get(channel.getUsersHere().get(0).getLongID() == Long.parseUnsignedLong(event.user_id) ? 0 : 1);
 		} else {
 			user = channel.getGuild().getUserByID(Long.parseUnsignedLong(event.user_id));
 		}


### PR DESCRIPTION
### Prerequisites
* [x] I have read and understood the [contribution guidelines](CONTRIBUTING.md)
* [x] This pull request follows the code style of the project
* [x] I have tested this feature thoroughly
  * [Proof of testing](https://i.imgur.com/ZnG29kx.png)
  * [Proof of testing](https://i.imgur.com/kfu7Bxf.png)

**Issues Fixed:**
Currently ReactionEvent's user variable is set to the recipient regardless of which account adds or removes the reaction, this fixes that.
