### PR TITLE
Remove null elements from User#getRolesForGuild()

### DIFF
--- a/src/main/java/sx/blah/discord/handle/impl/obj/Message.java
+++ b/src/main/java/sx/blah/discord/handle/impl/obj/Message.java
@@ -144,7 +144,7 @@ public class Message implements IMessage {
 	/**
 	 * Pattern for Discord's channel mentions.
 	 */
-	private static final Pattern CHANNEL_PATTERN = Pattern.compile("<#([0-9]+)>");
+	private static final Pattern CHANNEL_PATTERN = Pattern.compile("<#([0-9]{1,19})>");
 
 	/**
 	 * Whether the message was deleted.

--- a/src/main/java/sx/blah/discord/handle/impl/obj/Message.java
+++ b/src/main/java/sx/blah/discord/handle/impl/obj/Message.java
@@ -144,7 +144,7 @@ public class Message implements IMessage {
 	/**
 	 * Pattern for Discord's channel mentions.
 	 */
-	private static final Pattern CHANNEL_PATTERN = Pattern.compile("<#([0-9]{1,19})>");
+	private static final Pattern CHANNEL_PATTERN = Pattern.compile("<#([0-9]+)>");
 
 	/**
 	 * Whether the message was deleted.

--- a/src/main/java/sx/blah/discord/handle/impl/obj/User.java
+++ b/src/main/java/sx/blah/discord/handle/impl/obj/User.java
@@ -36,7 +36,6 @@ import sx.blah.discord.util.cache.LongMap;
 import java.awt.Color;
 import java.util.*;
 import java.util.concurrent.CopyOnWriteArraySet;
-import java.util.stream.Collectors;
 
 /**
  * The default implementation of {@link IUser}.
@@ -212,7 +211,7 @@ public class User implements IUser {
 		if (roles != null) {
 			RolesHolder retrievedRoles = roles.get(guild.getLongID());
 			if (retrievedRoles != null && retrievedRoles.getObject() != null)
-				return new LinkedList<>(retrievedRoles.getObject().stream().filter(Objects::nonNull).collect(Collectors.toList()));
+				return new LinkedList<>(retrievedRoles.getObject());
 		}
 
 		return new LinkedList<>();

--- a/src/main/java/sx/blah/discord/handle/impl/obj/User.java
+++ b/src/main/java/sx/blah/discord/handle/impl/obj/User.java
@@ -36,6 +36,7 @@ import sx.blah.discord.util.cache.LongMap;
 import java.awt.Color;
 import java.util.*;
 import java.util.concurrent.CopyOnWriteArraySet;
+import java.util.stream.Collectors;
 
 /**
  * The default implementation of {@link IUser}.
@@ -211,7 +212,7 @@ public class User implements IUser {
 		if (roles != null) {
 			RolesHolder retrievedRoles = roles.get(guild.getLongID());
 			if (retrievedRoles != null && retrievedRoles.getObject() != null)
-				return new LinkedList<>(retrievedRoles.getObject());
+				return new LinkedList<>(retrievedRoles.getObject().stream().filter(Objects::nonNull).collect(Collectors.toList()));
 		}
 
 		return new LinkedList<>();

--- a/src/main/java/sx/blah/discord/handle/impl/obj/User.java
+++ b/src/main/java/sx/blah/discord/handle/impl/obj/User.java
@@ -212,7 +212,7 @@ public class User implements IUser {
 		if (roles != null) {
 			RolesHolder retrievedRoles = roles.get(guild.getLongID());
 			if (retrievedRoles != null && retrievedRoles.getObject() != null)
-				return new LinkedList<>(retrievedRoles.getObject().stream().filter(Objects::nonNull).collect(Collectors.toList()));
+				return retrievedRoles.getObject().stream().filter(Objects::nonNull).collect(Collectors.toCollection(LinkedList::new));
 		}
 
 		return new LinkedList<>();


### PR DESCRIPTION
### Prerequisites
* [X] I have read and understood the [contribution guidelines](CONTRIBUTING.md)
* [X] This pull request follows the code style of the project
* [X] I have tested this feature thoroughly
  * I've tested this fix with my bot, nothing bad happened

**Issues Fixed:** https://github.com/austinv11/Discord4J/issues/392

### Changes Proposed in this Pull Request
* Remove null elements contained in `retrievedRoles.getObject()` leading to a NullPointerException while cheking permissions in PermissionUtils.