### PR TITLE
Fix ReactionEmoji::toString and add support for animated emojis

### DIFF
--- a/src/main/java/sx/blah/discord/api/internal/DiscordUtils.java
+++ b/src/main/java/sx/blah/discord/api/internal/DiscordUtils.java
@@ -722,7 +722,7 @@ public class DiscordUtils {
 		if (json != null)
 			for (MessageObject.ReactionObject object : json) {
 				long id = object.emoji.id == null ? 0 : Long.parseUnsignedLong(object.emoji.id);
-				ReactionEmoji emoji = ReactionEmoji.of(object.emoji.name, id);
+				ReactionEmoji emoji = ReactionEmoji.of(object.emoji.name, id, object.emoji.animated);
 				reactions.add(new Reaction(message, object.count, emoji));
 			}
 

--- a/src/main/java/sx/blah/discord/api/internal/DispatchHandler.java
+++ b/src/main/java/sx/blah/discord/api/internal/DispatchHandler.java
@@ -802,7 +802,7 @@ class DispatchHandler {
 		if (wasCached) {
 			if (reaction == null) { // Only happens in the case of a cached message with a new reaction
 				long id = event.emoji.id == null ? 0 : Long.parseUnsignedLong(event.emoji.id);
-				reaction = new Reaction(message, 1, ReactionEmoji.of(event.emoji.name, id));
+				reaction = new Reaction(message, 1, ReactionEmoji.of(event.emoji.name, id, event.emoji.animated));
 				message.getReactions().add(reaction);
 			} else {
 				((Reaction) reaction).setCount(reaction.getCount() + 1);
@@ -842,7 +842,7 @@ class DispatchHandler {
 		if (wasCached) {
 			if (reaction == null) { // the last reaction of the emoji was removed
 				long id = event.emoji.id == null ? 0 : Long.parseUnsignedLong(event.emoji.id);
-				reaction = new Reaction(message, 0, ReactionEmoji.of(event.emoji.name, id));
+				reaction = new Reaction(message, 0, ReactionEmoji.of(event.emoji.name, id, event.emoji.animated));
 			} else {
 				((Reaction) reaction).setCount(reaction.getCount() - 1);
 				if (reaction.getCount() <= 0) {

--- a/src/main/java/sx/blah/discord/api/internal/json/objects/ReactionEmojiObject.java
+++ b/src/main/java/sx/blah/discord/api/internal/json/objects/ReactionEmojiObject.java
@@ -29,4 +29,8 @@ public class ReactionEmojiObject {
 	 * The ID of the emoji.
 	 */
 	public String id;
+	/**
+	 * Wheter this emoji is animated.
+	 */
+	public boolean animated = false;
 }

--- a/src/main/java/sx/blah/discord/handle/impl/obj/ReactionEmoji.java
+++ b/src/main/java/sx/blah/discord/handle/impl/obj/ReactionEmoji.java
@@ -98,7 +98,7 @@ public class ReactionEmoji implements IIDLinkedObject {
 
 	@Override
 	public String toString() {
-		return isUnicode() ? getName() : "<" + getName() + ":" + Long.toUnsignedString(getLongID()) + ">";
+		return isUnicode() ? getName() : "<:" + getName() + ":" + Long.toUnsignedString(getLongID()) + ">";
 	}
 
 	@Override

--- a/src/main/java/sx/blah/discord/handle/impl/obj/ReactionEmoji.java
+++ b/src/main/java/sx/blah/discord/handle/impl/obj/ReactionEmoji.java
@@ -35,18 +35,30 @@ public class ReactionEmoji implements IIDLinkedObject {
 	 * @return A reaction emoji with the name and ID of the given guild emoji.
 	 */
 	public static ReactionEmoji of(IEmoji emoji) {
-		return of(emoji.getName(), emoji.getLongID());
+		return of(emoji.getName(), emoji.getLongID(), emoji.isAnimated());
+	}
+
+	/**
+	 * Constructs a {@link ReactionEmoji} from the given name, ID and animated flag.
+	 *
+	 * @param name       The name of the emoji.
+	 * @param id         The ID of the emoji.
+	 * @param isAnimated Whether the emoji is animated.
+	 * @return A reaction emoji with the given name and ID.
+	 */
+	public static ReactionEmoji of(String name, long id, boolean isAnimated) {
+		return new ReactionEmoji(name, id, isAnimated);
 	}
 
 	/**
 	 * Constructs a {@link ReactionEmoji} from the given name and ID.
 	 *
 	 * @param name The name of the emoji.
-	 * @param id The ID of the emoji.
+	 * @param id   The ID of the emoji.
 	 * @return A reaction emoji with the given name and ID.
 	 */
 	public static ReactionEmoji of(String name, long id) {
-		return new ReactionEmoji(name, id);
+		return new ReactionEmoji(name, id, false);
 	}
 
 	/**
@@ -56,7 +68,7 @@ public class ReactionEmoji implements IIDLinkedObject {
 	 * @return A reaction emoji with the given unicode emoji.
 	 */
 	public static ReactionEmoji of(String unicode) {
-		return new ReactionEmoji(unicode, 0L);
+		return new ReactionEmoji(unicode, 0L, false);
 	}
 
 	/**
@@ -67,10 +79,15 @@ public class ReactionEmoji implements IIDLinkedObject {
 	 * The unique snowflake ID of the reaction emoji. The the emoji is a unicode emoji, this value is <code>0</code>.
 	 */
 	private final long id;
+	/**
+	 * Whether the emoji is animated.
+	 */
+	private final boolean isAnimated;
 
-	private ReactionEmoji(String name, long id) {
+	private ReactionEmoji(String name, long id, boolean isAnimated) {
 		this.name = name;
 		this.id = id;
+		this.isAnimated = isAnimated;
 	}
 
 	/**
@@ -91,6 +108,16 @@ public class ReactionEmoji implements IIDLinkedObject {
 		return id == 0;
 	}
 
+	/**
+	 * Gets whether the emoji is animated.
+	 *
+	 * @return Whether the emoji is animated.
+	 */
+	public boolean isAnimated() {
+		return isAnimated;
+	}
+
+
 	@Override
 	public long getLongID() {
 		return id;
@@ -98,7 +125,7 @@ public class ReactionEmoji implements IIDLinkedObject {
 
 	@Override
 	public String toString() {
-		return isUnicode() ? getName() : "<:" + getName() + ":" + Long.toUnsignedString(getLongID()) + ">";
+		return isUnicode() ? getName() : "<" + (isAnimated() ? "a" : "") + ":" + getName() + ":" + Long.toUnsignedString(getLongID()) + ">";
 	}
 
 	@Override


### PR DESCRIPTION
### Prerequisites
* [x] I have read and understood the [contribution guidelines](CONTRIBUTING.md)
* [x] This pull request follows the code style of the project
* [x] I have tested this feature thoroughly
  * ![result](https://i.imgur.com/4wGJk8u.png)
  Custom emoji inserted in embed using
   ![image](https://user-images.githubusercontent.com/4102586/36435122-1272941c-1661-11e8-9d62-6baeb9fc1ddb.png)
 ![image](https://user-images.githubusercontent.com/4102586/36435141-26be7bf2-1661-11e8-8f61-c87cd99f6191.png)


)

**Issues Fixed:** ReactionEmoji::toString was not including the first `:` for custom emojis, support for animated emojis was also missing.

### Changes Proposed in this Pull Request
* Added `:` before emoji name in toString (`<:name:id>`)
* For animated emojis also added `a` before first `:` (`<a:name:id>`)