### PR TITLE
Added to string method

### DIFF
--- a/src/main/java/sx/blah/discord/handle/impl/obj/Presence.java
+++ b/src/main/java/sx/blah/discord/handle/impl/obj/Presence.java
@@ -89,6 +89,12 @@ public class Presence implements IPresence {
 		return Objects.hash(text, streamingUrl, status, activity);
 	}
 
+	
+	@Override
+	public String toString() {
+		return text;
+	}
+	
 	@Override
 	public Optional<ActivityType> getActivity() {
 		return Optional.ofNullable(activity);


### PR DESCRIPTION
### Prerequisites
* [ ] I have read and understood the [contribution guidelines](CONTRIBUTING.md)
* [ ] This pull request follows the code style of the project
* [ ] I have tested this feature thoroughly
 * [Proof of testing](screenshot, any evidence you tested this pull request)
![image](https://user-images.githubusercontent.com/5445550/37243216-e92dfb6c-246d-11e8-8354-f171dd674feb.png)

**Issues Fixed:** [The issues fixed by this pull request]
Before logging would print the object reference rather than the object value for example "User "Discord Status" changed presence to sx.blah.discord.handle.impl.obj.Presence@c8cc6d3a" which is of no real use now rather than printing the object reference we are printing the values for example "14:19:42.428: [DEBUG][Dispatch Handler][sx.blah.discord.Discord4J] - User "Discord Status" changed presence to Presence(Giving 1601 Servers Status's!:null:ONLINE:PLAYING)"
### Changes Proposed in this Pull Request
* [Change 1] Added a to string method to Presence

